### PR TITLE
feat: Allow admins to assign surveys to agents

### DIFF
--- a/server/controllers/surveys.js
+++ b/server/controllers/surveys.js
@@ -6,7 +6,7 @@ import { Readable } from 'stream';
 
 export const createSurvey = async (req, res, next) => {
   try {
-    const { title, description, questions: inputQuestions, status, companyId: bodyCompanyId } = req.body;
+    const { title, description, questions: inputQuestions, status, companyId: bodyCompanyId, agentId } = req.body;
     const { id: userId, role: userRole, companyId: userCompanyId } = req.user;
 
     const db = getDb();
@@ -51,6 +51,10 @@ export const createSurvey = async (req, res, next) => {
       if (bodyCompanyId && bodyCompanyId !== userCompanyId.toString() && userRole !== 'admin') {
         console.warn(`User ${userId} (role: ${userRole}) attempted to set companyId to ${bodyCompanyId} but is associated with ${userCompanyId}. Using user's companyId.`);
       }
+    }
+
+    if (userRole === 'admin' && agentId && ObjectId.isValid(agentId)) {
+      newSurveyData.agentId = new ObjectId(agentId);
     }
 
     const result = await db.collection('surveys').insertOne(newSurveyData);
@@ -123,7 +127,7 @@ export const updateSurvey = async (req, res, next) => {
     const db = getDb();
     const { id: surveyId } = req.params;
     const { id: userId, role: userRole } = req.user;
-    const { title, description, questions: inputQuestions, status, companyId: bodyCompanyId } = req.body;
+    const { title, description, questions: inputQuestions, status, companyId: bodyCompanyId, agentId } = req.body;
 
     if (!ObjectId.isValid(surveyId)) {
       throw new ApiError(404, 'Survey not found (invalid ID format)');
@@ -175,6 +179,16 @@ export const updateSurvey = async (req, res, next) => {
         } else {
             throw new ApiError(400, 'Invalid Company ID format provided for update by admin.');
         }
+    }
+
+    if (userRole === 'admin' && agentId !== undefined) {
+      if (agentId === null || agentId === '') {
+        updateFields.agentId = null;
+      } else if (ObjectId.isValid(agentId)) {
+        updateFields.agentId = new ObjectId(agentId);
+      } else {
+        throw new ApiError(400, 'Invalid Agent ID format provided for update by admin.');
+      }
     }
 
     if (Object.keys(updateFields).length === 0) {

--- a/server/routes/surveys.js
+++ b/server/routes/surveys.js
@@ -26,6 +26,7 @@ router.post('/', [
   body('title').notEmpty().withMessage('Title is required').trim(),
   body('description').optional().trim(),
   body('questions').optional().isArray().withMessage('Questions must be an array'),
+  body('agentId').optional({ checkFalsy: true }).isMongoId().withMessage('Invalid Agent ID format'),
   // status and companyId are handled in controller or can be added here if strict validation from client is needed
   validateRequest
 ], createSurvey);
@@ -45,6 +46,7 @@ router.put('/:id', [
   body('status').optional().isIn(['draft', 'active', 'completed']),
   body('questions').optional().isArray().withMessage('Questions must be an array'),
   body('companyId').optional({ checkFalsy: true }).isMongoId().withMessage('Invalid Company ID format'),
+  body('agentId').optional({ checkFalsy: true }).isMongoId().withMessage('Invalid Agent ID format'),
   validateRequest
 ], updateSurvey);
 

--- a/src/pages/Surveys.tsx
+++ b/src/pages/Surveys.tsx
@@ -13,6 +13,7 @@ interface SurveyFormData {
   title: string;
   description: string;
   questions: SurveyQuestion[];
+  agentId?: string;
 }
 
 const SurveyForm: React.FC<{
@@ -21,7 +22,9 @@ const SurveyForm: React.FC<{
   onSubmit: (e: React.FormEvent) => Promise<void>;
   onCancel: () => void;
   buttonText: string;
-}> = React.memo(({ formData, onFormDataChange, onSubmit, onCancel, buttonText }) => {
+  agents: any[];
+  user: any;
+}> = React.memo(({ formData, onFormDataChange, onSubmit, onCancel, buttonText, agents, user }) => {
 
   if (!formData || !Array.isArray(formData.questions)) {
     return <div>Loading survey form...</div>;
@@ -179,6 +182,27 @@ const SurveyForm: React.FC<{
         <Button type="button" variant="outline" onClick={onCancel}>
           Cancel
         </Button>
+        {user?.role === 'admin' && (
+          <div className="col-span-1">
+            <label htmlFor="agentId" className="block text-sm font-medium text-gray-700">
+              Assign to Agent (Optional)
+            </label>
+            <select
+              id="agentId"
+              name="agentId"
+              value={formData.agentId || ''}
+              onChange={(e) => onFormDataChange({ ...formData, agentId: e.target.value })}
+              className="mt-1 block w-full pl-3 pr-10 py-2 text-base border-gray-300 focus:outline-none focus:ring-primary-500 focus:border-primary-500 sm:text-sm rounded-md"
+            >
+              <option value="">-- Select Agent --</option>
+              {agents.map((agent) => (
+                <option key={agent._id} value={agent._id}>
+                  {agent.name} ({agent.email})
+                </option>
+              ))}
+            </select>
+          </div>
+        )}
         <Button type="submit" variant="primary">
           {buttonText}
         </Button>
@@ -211,6 +235,7 @@ const Surveys: React.FC = () => {
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const [uploadStatusMessage, setUploadStatusMessage] = useState<string | null>(null);
   const [isUploading, setIsUploading] = useState(false);
+  const [agents, setAgents] = useState<any[]>([]);
 
   const resetForm = useCallback(() => {
     setFormData({
@@ -229,6 +254,28 @@ const Surveys: React.FC = () => {
       }));
     }
   }, []);
+
+  useEffect(() => {
+    const fetchAgents = async () => {
+      if (user?.role !== 'admin') return;
+      const token = localStorage.getItem('authToken');
+      if (!token) return;
+
+      try {
+        const response = await fetch('/api/users?role=agent', {
+          headers: { 'Authorization': `Bearer ${token}` },
+        });
+        if (response.ok) {
+          const { data } = await response.json();
+          setAgents(data || []);
+        }
+      } catch (error) {
+        console.error("Failed to fetch agents:", error);
+      }
+    };
+
+    fetchAgents();
+  }, [user]);
 
   useEffect(() => {
     const fetchApiSurveys = async () => {
@@ -305,6 +352,7 @@ const Surveys: React.FC = () => {
           title: formData.title,
           description: formData.description,
           questions: formData.questions,
+          agentId: formData.agentId,
         }),
       });
 
@@ -354,6 +402,7 @@ const Surveys: React.FC = () => {
           title: formData.title,
           description: formData.description,
           questions: formData.questions,
+          agentId: formData.agentId,
         }),
       });
 
@@ -688,6 +737,8 @@ const Surveys: React.FC = () => {
           onSubmit={handleAddSurvey}
           onCancel={handleCancelAdd}
           buttonText="Create Survey"
+          agents={agents}
+          user={user}
         />
       </Modal>
 
@@ -702,6 +753,8 @@ const Surveys: React.FC = () => {
           onSubmit={handleEditSurvey}
           onCancel={handleCancelEdit}
           buttonText="Save Changes"
+          agents={agents}
+          user={user}
         />
       </Modal>
 


### PR DESCRIPTION
This commit introduces the ability for admins to assign surveys to agents.

- Updates the survey creation and update routes to accept an `agentId`.
- Modifies the `createSurvey` and `updateSurvey` controller functions to handle the `agentId`.
- Adds a dropdown menu to the survey form on the frontend, allowing admins to select an agent when creating or editing a survey.