### PR TITLE
fix: Correct survey update validation and PPTX export

### DIFF
--- a/server/controllers/reports.js
+++ b/server/controllers/reports.js
@@ -118,7 +118,8 @@ export const getReportById = async (req, res) => {
           pptx.layout = 'MASTER_SLIDE';
         }
         if (company.branding.logo) {
-          pptx.addSlide().addImage({ path: company.branding.logo, x: 1, y: 1, w: 1, h: 1 });
+          // Assuming the logo is a base64 string, prepend the necessary data URI scheme
+          pptx.addSlide().addImage({ data: `data:image/png;base64,${company.branding.logo}`, x: 1, y: 1, w: 1, h: 1 });
         }
       }
 

--- a/server/controllers/surveys.js
+++ b/server/controllers/surveys.js
@@ -173,7 +173,7 @@ export const updateSurvey = async (req, res, next) => {
         if (!q.text || typeof q.text !== 'string' || q.text.trim() === '') {
           throw new ApiError(400, `Update: Question '${q.id}' (index ${index}) must have non-empty 'text'.`);
         }
-        if (!q.type || typeof q.type !== 'string' || !['text', 'textarea', 'single-choice', 'multiple-choice', 'rating'].includes(q.type)) {
+        if (!q.type || typeof q.type !== 'string' || !['text', 'textarea', 'single-choice', 'multiple-choice', 'rating', 'nps', 'ces', 'image-choice', 'file-upload', 'video'].includes(q.type)) {
           throw new ApiError(400, `Update: Question '${q.id}' (index ${index}) has an invalid 'type'.`);
         }
         return {


### PR DESCRIPTION
This commit addresses two issues:

1.  A bug where updating a survey with a new question type (e.g., NPS, video) would fail due to incomplete validation logic on the backend. The `updateSurvey` controller now correctly validates all available question types.

2.  A failure in downloading reports in PPTX format, caused by an incorrect method of embedding a company logo. The code now uses the `data` option instead of `path` to include the logo, which is the correct approach for base64-encoded images.