### PR TITLE
fix: Handle undefined description in survey filter

### DIFF
--- a/src/pages/Surveys.tsx
+++ b/src/pages/Surveys.tsx
@@ -548,8 +548,8 @@ const Surveys: React.FC = () => {
   }, [selectedFile, uploadTargetSurveyId]);
 
   const filteredSurveys = surveys.filter(survey =>
-    survey.title.toLowerCase().includes(searchTerm.toLowerCase()) ||
-    survey.description.toLowerCase().includes(searchTerm.toLowerCase())
+    (survey.title && survey.title.toLowerCase().includes(searchTerm.toLowerCase())) ||
+    (survey.description && survey.description.toLowerCase().includes(searchTerm.toLowerCase()))
   );
 
   const getStatusColor = (status: string) => {


### PR DESCRIPTION
This commit fixes a bug where the survey filter would crash if a survey had an undefined description. The filter now checks for the existence of the description before attempting to call `toLowerCase()` on it.