### PR TITLE
Feat: Add landing page and footers to reports

### DIFF
--- a/server/controllers/reports.js
+++ b/server/controllers/reports.js
@@ -3,7 +3,7 @@ import { ObjectId } from 'mongodb';
 import PDFDocument from 'pdfkit';
 import pptxgen from 'pptxgenjs';
 import Excel from 'exceljs';
-import { createStudyOverviewSlide } from '../templates/study-overview.js';
+import { createStudyOverviewSlide, createLandingPageSlide } from '../templates/study-overview.js';
 
 // @desc    Generate a new report
 // @route   POST /api/reports
@@ -164,6 +164,9 @@ export const getReportById = async (req, res) => {
         }
       }
 
+      // --- Landing Page ---
+      createLandingPageSlide(pptx, survey);
+
       // --- Study Overview ---
       createStudyOverviewSlide(pptx, survey);
 
@@ -222,6 +225,23 @@ export const getReportById = async (req, res) => {
       historicalSlide.addText('Historical Trend Comparisons', { x: 1, y: 1, fontSize: 24, bold: true });
       historicalSlide.addText('Historical trend comparisons will be added in a future update.', { x: 1, y: 2 });
 
+      // --- Add Footers ---
+      const firstRespondent = responses[0] || {};
+      const respondentName = firstRespondent.respondentName || 'N/A';
+      const respondentLocation = firstRespondent.location ? `${firstRespondent.location.city}, ${firstRespondent.location.country}` : 'N/A';
+      const respondentResponse = firstRespondent.response ? JSON.stringify(firstRespondent.response).substring(0, 50) + '...' : 'N/A';
+
+      pptx.slides.forEach((slide, index) => {
+        slide.addText(
+          `Respondent: ${respondentName} | Location: ${respondentLocation} | Response: ${respondentResponse}`,
+          { x: 0.5, y: 5.2, fontSize: 8, color: '666666' }
+        );
+        slide.addText(
+            `Slide ${index + 1}`,
+            { x: 9, y: 5.2, fontSize: 8, color: '666666' }
+        );
+      });
+
       const buffer = await pptx.write('buffer');
       res.writeHead(200, {
         'Content-Type': 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
@@ -259,18 +279,37 @@ export const getReportById = async (req, res) => {
         }).end(pdfData);
       });
 
-      doc.fontSize(25).text(report.title, {
+      // --- PDF Landing Page ---
+      doc.image('logo.png', {
+        fit: [100, 100],
+        align: 'center',
+        valign: 'center'
+      });
+      doc.moveDown(2);
+      doc.fontSize(25).text(survey.title, {
         align: 'center'
       });
 
-      doc.moveDown();
-
-      report.sections.forEach(section => {
-        doc.fontSize(20).text(section.type, {
+      // --- PDF Content ---
+      report.sections.forEach((section, pageIndex) => {
+        doc.addPage();
+        doc.fontSize(20).text(section.title, {
           underline: true
         });
-        doc.fontSize(12).text(section.content);
-        doc.moveDown();
+        doc.fontSize(12).text(section.content.toString());
+
+        // --- PDF Footer ---
+        const firstRespondent = responses[0] || {};
+        const respondentName = firstRespondent.respondentName || 'N/A';
+        const respondentLocation = firstRespondent.location ? `${firstRespondent.location.city}, ${firstRespondent.location.country}` : 'N/A';
+        const respondentResponse = firstRespondent.response ? JSON.stringify(firstRespondent.response).substring(0, 50) + '...' : 'N/A';
+
+        doc.fontSize(8).text(
+          `Respondent: ${respondentName} | Location: ${respondentLocation} | Response: ${respondentResponse}`,
+          50,
+          750,
+          { align: 'center' }
+        );
       });
 
       doc.end();

--- a/server/templates/study-overview.js
+++ b/server/templates/study-overview.js
@@ -6,3 +6,10 @@ export const createStudyOverviewSlide = (pptx, survey) => {
   slide.addText(`Objectives: ${survey.objectives || 'N/A'}`, { x: 1, y: 3 });
   slide.addText(`Methodology: ${survey.methodology || 'N/A'}`, { x: 1, y: 3.5 });
 };
+
+export const createLandingPageSlide = (pptx, survey) => {
+  const slide = pptx.addSlide();
+  // Add Signaplus logo
+  slide.addImage({ path: 'logo.png', x: 1, y: 1, w: 2, h: 1 });
+  slide.addText(survey.title, { x: 1, y: 3, fontSize: 32, bold: true, align: 'center' });
+};


### PR DESCRIPTION
This commit introduces a landing page with the Signaplus logo and survey name to both PDF and PPTX reports. It also adds a footer to each page of the reports, containing the respondent's name, location, and response.