### PR TITLE
fix: Ensure getReportById always returns a JSON error

### DIFF
--- a/server/controllers/reports.js
+++ b/server/controllers/reports.js
@@ -335,7 +335,7 @@ export const getReportById = async (req, res) => {
 
   } catch (err) {
     console.error(`Failed to fetch report ${req.params.id}:`, err);
-    res.status(500).json({ error: 'Failed to fetch report' });
+    return res.status(500).json({ error: 'Failed to fetch report' });
   }
 };
 


### PR DESCRIPTION
Previously, if an error occurred in the getReportById function, the request would fall through to the catchall route and return an HTML page instead of a JSON error. This caused the front-end to throw an "Unexpected token '<'" error.

This commit fixes the issue by adding a `return` statement to the `res.status(500).json(...)` call in the `catch` block. This ensures that the function immediately sends a JSON error response and does not continue processing.