### PR TITLE
fix: remove postinstall script

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
     "server": "JWT_SECRET=averysecretkey node server/index.js",
     "build": "tsc && vite build",
     "lint": "eslint src --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
-    "preview": "vite preview",
-    "postinstall": "apt-get update && apt-get install -y build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev"
+    "preview": "vite preview"
   },
   "dependencies": {
     "bcryptjs": "^2.4.3",


### PR DESCRIPTION
The postinstall script was causing deployment failures by trying to install system-level dependencies in an environment where it lacked the necessary permissions. Removing the script resolves the deployment issue.