### PR TITLE
Fix(reports): use buffer to prevent PDF corruption

### DIFF
--- a/server/controllers/reports.js
+++ b/server/controllers/reports.js
@@ -188,9 +188,17 @@ export const downloadReport = async (req, res) => {
         try {
           console.log('Generating PDF report');
           const doc = new PDFDocument();
-          const tmpFile = tmp.fileSync({ postfix: '.pdf' });
-          const stream = fs.createWriteStream(tmpFile.name);
-          doc.pipe(stream);
+          const buffers = [];
+          doc.on('data', buffers.push.bind(buffers));
+          doc.on('end', () => {
+            const pdfData = Buffer.concat(buffers);
+            res.writeHead(200, {
+              'Content-Type': 'application/pdf',
+              'Content-Disposition': `attachment; filename=${report.title}.pdf`,
+              'Content-Length': pdfData.length,
+            });
+            res.end(pdfData);
+          });
 
           // --- PDF Landing Page ---
           doc.image(Buffer.from(logo, 'base64'), {
@@ -216,19 +224,6 @@ export const downloadReport = async (req, res) => {
             });
           }
           doc.end();
-
-          await new Promise((resolve, reject) => {
-            stream.on('finish', resolve);
-            stream.on('error', reject);
-          });
-
-          res.download(tmpFile.name, `${report.title}.pdf`, (err) => {
-            if (err) {
-              console.error('Error sending pdf file:', err);
-            }
-            tmpFile.removeCallback();
-          });
-
           console.log('PDF report sent');
         } catch (e) {
           console.error('Error generating pdf file:', e);


### PR DESCRIPTION
This commit refactors the PDF generation process to resolve a persistent corruption issue.

Instead of writing to a temporary file, the PDF is now generated in-memory as a buffer. This buffer is then sent directly to you with the appropriate headers. This approach avoids potential race conditions and file system issues that were likely causing the corruption.

The PPTX generation logic remains unchanged.