### PR TITLE
Fix(reports): remove logo from PDF to prevent corruption

### DIFF
--- a/server/controllers/reports.js
+++ b/server/controllers/reports.js
@@ -201,11 +201,6 @@ export const downloadReport = async (req, res) => {
           });
 
           // --- PDF Landing Page ---
-          doc.image(Buffer.from(logo, 'base64'), {
-            fit: [100, 100],
-            align: 'center',
-            valign: 'center'
-          });
           doc.moveDown(2);
           doc.fontSize(25).text(survey.title, {
             align: 'center'


### PR DESCRIPTION
This commit removes the logo from the PDF generation process as a final attempt to resolve the persistent corruption issue.

After multiple failed attempts to fix the PDF generation, it is possible that the issue is related to the logo image itself or how it's being processed. By removing the logo, we can isolate the problem and determine if the image is the root cause.

The PPTX and XLSX generation logic remains unchanged.