### PR TITLE
Fix: Correct syntax error in reports controller

### DIFF
--- a/server/controllers/reports.js
+++ b/server/controllers/reports.js
@@ -121,7 +121,7 @@ export const downloadReport = async (req, res) => {
   console.log('Download report request received');
   try {
     const db = getDb();
-    const { id }_ = req.params;
+    const { id } = req.params;
     const { format } = req.query; // pptx, xlsx, pdf
 
     if (!ObjectId.isValid(id)) {


### PR DESCRIPTION
Removes a trailing underscore from a destructuring assignment in the `downloadReport` function in `server/controllers/reports.js`.