### PR TITLE
Fix: Correct survey details navigation

### DIFF
--- a/src/pages/ProjectDetails.tsx
+++ b/src/pages/ProjectDetails.tsx
@@ -332,7 +332,7 @@ const ProjectDetails: React.FC = () => {
                     <Button
                       variant="outline"
                       size="sm"
-                      onClick={() => navigate(`/surveys/details/${survey.id}`)}
+                      onClick={() => navigate(`/surveys/${survey.id}`)}
                     >
                       View Details
                     </Button>


### PR DESCRIPTION
Corrects the navigation to the survey details page from the project details page. The route was previously `/surveys/details/:id`, and has been corrected to `/surveys/:id`.