### PR TITLE
Fix(reports): Save PDF to temporary file before sending

### DIFF
--- a/server/controllers/reports.js
+++ b/server/controllers/reports.js
@@ -121,7 +121,7 @@ export const downloadReport = async (req, res) => {
   console.log('Download report request received');
   try {
     const db = getDb();
-    const { id }_ = req.params;
+    const { id } = req.params;
     const { format } = req.query; // pptx, xlsx, pdf
 
     if (!ObjectId.isValid(id)) {
@@ -220,9 +220,19 @@ export const downloadReport = async (req, res) => {
           }
 
           const pdfBytes = await pdfDoc.save();
+
+          const tmpFile = tmp.fileSync({ postfix: '.pdf' });
+          fs.writeFileSync(tmpFile.name, pdfBytes);
+
           res.setHeader('Content-Type', 'application/pdf');
           res.setHeader('Content-Disposition', `attachment; filename=${report.title}.pdf`);
-          res.send(Buffer.from(pdfBytes));
+          res.sendFile(tmpFile.name, (err) => {
+            if (err) {
+              console.error('Error sending PDF file:', err);
+              res.status(500).json({ error: 'Failed to send PDF file' });
+            }
+            tmpFile.removeCallback();
+          });
           console.log('PDF report sent');
         } catch (e) {
           console.error('Error generating pdf file:', e);

--- a/server/index.js
+++ b/server/index.js
@@ -13,6 +13,8 @@ import authRoutes from './routes/auth.js';
 import { verifyToken, authorizeRole } from './middleware/auth.js';
 import { body, validationResult } from 'express-validator';
 import { logger } from './middleware/logger.js';
+import fs from 'fs';
+import tmp from 'tmp';
 
 import surveyRoutesFunction from './routes/surveys.js';
 import userRoutes from './routes/users.js';
@@ -141,9 +143,17 @@ app.get('/api/test-pdf', async (req, res) => {
     color: rgb(0, 0, 0),
   });
   const pdfBytes = await pdfDoc.save();
+  const tmpFile = tmp.fileSync({ postfix: '.pdf' });
+  fs.writeFileSync(tmpFile.name, pdfBytes);
   res.setHeader('Content-Type', 'application/pdf');
   res.setHeader('Content-Disposition', 'attachment; filename=test.pdf');
-  res.send(Buffer.from(pdfBytes));
+  res.sendFile(tmpFile.name, (err) => {
+    if (err) {
+      console.error('Error sending PDF file:', err);
+      res.status(500).json({ error: 'Failed to send PDF file' });
+    }
+    tmpFile.removeCallback();
+  });
 });
 
 app.get('/api/test-report', async (req, res) => {
@@ -162,9 +172,17 @@ app.get('/api/test-report', async (req, res) => {
       color: rgb(0, 0, 0),
     });
     const pdfBytes = await pdfDoc.save();
+    const tmpFile = tmp.fileSync({ postfix: '.pdf' });
+    fs.writeFileSync(tmpFile.name, pdfBytes);
     res.setHeader('Content-Type', 'application/pdf');
     res.setHeader('Content-Disposition', 'attachment; filename=test.pdf');
-    res.send(Buffer.from(pdfBytes));
+    res.sendFile(tmpFile.name, (err) => {
+      if (err) {
+        console.error('Error sending PDF file:', err);
+        res.status(500).json({ error: 'Failed to send PDF file' });
+      }
+      tmpFile.removeCallback();
+    });
   } else if (format === 'pptx') {
     const pptxgen = await import('pptxgenjs');
     const pptx = new pptxgen.default();


### PR DESCRIPTION
- I modified the PDF generation logic to save the file to a temporary location on the server before sending it to you.
- This should resolve the issue with corrupt PDF downloads.