### PR TITLE
Fix: Prevent premature loading state change

### DIFF
--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -52,7 +52,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
         localStorage.removeItem('authToken');
       }
     }
-    setIsLoading(false);
+    setTimeout(() => setIsLoading(false), 500);
   }, []);
 
   const login = async (email: string, password: string) => {


### PR DESCRIPTION
Adds a timeout to the `useEffect` hook in `AuthContext.tsx` to prevent the loading state from being set to false prematurely, which was causing the survey screen to disappear.