### PR TITLE
Feat: Make breadcrumbs clickable and show project name

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,22 +1,17 @@
 import React from 'react';
-import { useLocation } from 'react-router-dom';
-import { Menu, Bell } from 'lucide-react';
+import { Link } from 'react-router-dom';
+import { Menu, Bell, ChevronRight } from 'lucide-react';
 import { useAuth } from '../../context/AuthContext';
 import { Button } from '../ui/Button';
+import { useBreadcrumbs } from '../../hooks/useBreadcrumbs';
 
 interface HeaderProps {
   onToggleSidebar: () => void;
 }
 
 export const Header: React.FC<HeaderProps> = ({ onToggleSidebar }) => {
-  const location = useLocation();
   const { user } = useAuth();
-
-  const getPageTitle = () => {
-    const path = location.pathname;
-    if (path === '/') return 'Dashboard';
-    return path.charAt(1).toUpperCase() + path.slice(2).replace(/\//g, ' › ');
-  };
+  const breadcrumbs = useBreadcrumbs();
 
   return (
     <header className="bg-white border-b border-gray-200 sticky top-0 z-10 h-16 flex items-center justify-between px-4 md:px-6">
@@ -29,7 +24,18 @@ export const Header: React.FC<HeaderProps> = ({ onToggleSidebar }) => {
         >
           <Menu className="h-5 w-5" />
         </Button>
-        <h1 className="text-xl font-semibold text-gray-800">{getPageTitle()}</h1>
+        <nav className="hidden md:flex items-center text-sm font-medium">
+          {breadcrumbs.map((crumb, index) => (
+            <React.Fragment key={crumb.path}>
+              <Link to={crumb.path} className="text-gray-500 hover:text-gray-700">
+                {crumb.label}
+              </Link>
+              {index < breadcrumbs.length - 1 && (
+                <ChevronRight className="h-4 w-4 text-gray-400 mx-1" />
+              )}
+            </React.Fragment>
+          ))}
+        </nav>
       </div>
       
       <div className="flex items-center space-x-4">

--- a/src/hooks/useBreadcrumbs.tsx
+++ b/src/hooks/useBreadcrumbs.tsx
@@ -1,0 +1,49 @@
+import { useState, useEffect } from 'react';
+import { useLocation, useParams } from 'react-router-dom';
+
+interface Breadcrumb {
+  label: string;
+  path: string;
+}
+
+export const useBreadcrumbs = () => {
+  const location = useLocation();
+  const params = useParams();
+  const [breadcrumbs, setBreadcrumbs] = useState<Breadcrumb[]>([]);
+
+  useEffect(() => {
+    const generateBreadcrumbs = async () => {
+      const pathnames = location.pathname.split('/').filter((x) => x);
+      const newBreadcrumbs: Breadcrumb[] = [{ label: 'Home', path: '/' }];
+
+      for (let i = 0; i < pathnames.length; i++) {
+        const path = `/${pathnames.slice(0, i + 1).join('/')}`;
+        let label = pathnames[i].charAt(0).toUpperCase() + pathnames[i].slice(1);
+
+        if (pathnames[i] === 'projects' && params.projectId) {
+          try {
+            const token = localStorage.getItem('authToken');
+            const response = await fetch(`/api/projects/${params.projectId}`, {
+              headers: {
+                'Authorization': `Bearer ${token}`,
+              },
+            });
+            if (response.ok) {
+              const project = await response.json();
+              label = project.data.title;
+            }
+          } catch (error) {
+            console.error('Failed to fetch project details:', error);
+          }
+        }
+
+        newBreadcrumbs.push({ label, path });
+      }
+      setBreadcrumbs(newBreadcrumbs);
+    };
+
+    generateBreadcrumbs();
+  }, [location, params]);
+
+  return breadcrumbs;
+};


### PR DESCRIPTION
- Creates a `useBreadcrumbs` hook to generate breadcrumbs.
- Fetches project name to display in the breadcrumb instead of the project ID.
- Renders breadcrumbs as clickable links in the header.