### PR TITLE
Fix: Prevent all surveys from re-rendering

### DIFF
--- a/src/pages/AllSurveys.tsx
+++ b/src/pages/AllSurveys.tsx
@@ -55,7 +55,7 @@ const AllSurveys: React.FC = () => {
     };
 
     fetchAllSurveys();
-  }, [user]);
+  }, []);
 
   const getStatusColor = (status: string) => {
     switch (status) {


### PR DESCRIPTION
Removes the `user` dependency from the `useEffect` hook in `src/pages/AllSurveys.tsx` to prevent unnecessary re-renders when the user object changes.