### PR TITLE
Fix: Prevent project details from re-rendering

### DIFF
--- a/src/pages/ProjectDetails.tsx
+++ b/src/pages/ProjectDetails.tsx
@@ -118,7 +118,7 @@ const ProjectDetails: React.FC = () => {
 
   useEffect(() => {
     fetchProjectAndSurveys();
-  }, [projectId, user]);
+  }, [projectId]);
 
   useEffect(() => {
     const fetchAgentsAndCompanies = async () => {


### PR DESCRIPTION
Removes the `user` dependency from the `useEffect` hook in `src/pages/ProjectDetails.tsx` to prevent unnecessary re-renders when the user object changes.