### PR TITLE
Fix: Surveys disappearing for agents

### DIFF
--- a/server/controllers/surveys.js
+++ b/server/controllers/surveys.js
@@ -51,6 +51,8 @@ export const createSurvey = async (req, res, next) => {
 
     if (userRole === 'admin' && agentId && ObjectId.isValid(agentId)) {
       newSurveyData.agentId = new ObjectId(agentId);
+    } else if (userRole === 'agent') {
+      newSurveyData.agentId = new ObjectId(userId);
     }
 
     if (customerId && ObjectId.isValid(customerId)) {
@@ -81,7 +83,10 @@ export const getSurveys = async (req, res, next) => {
       }
       query.companyIds = new ObjectId(userCompanyId);
     } else if (userRole === 'agent') {
-      query.agentId = new ObjectId(userId);
+      query.$or = [
+        { agentId: new ObjectId(userId) },
+        { createdBy: new ObjectId(userId) }
+      ];
     }
 
     if (region && region !== 'all') {
@@ -126,7 +131,9 @@ export const getSurveyById = async (req, res, next) => {
         throw new ApiError(403, 'Not authorized to access this survey');
       }
     } else if (userRole === 'agent') {
-      if (survey.createdBy.toString() !== userId.toString()) {
+      const isCreator = survey.createdBy.toString() === userId.toString();
+      const isAgent = survey.agentId && survey.agentId.toString() === userId.toString();
+      if (!isCreator && !isAgent) {
         throw new ApiError(403, 'Not authorized to access this survey');
       }
     }


### PR DESCRIPTION
This commit fixes an issue where surveys were disappearing for users with the 'agent' role.

The `createSurvey` function was not setting the `agentId` when a survey was created by an agent. This caused the `getSurveys` and `getSurveyById` functions to fail to retrieve the surveys for that agent.

The following changes were made:

- In `server/controllers/surveys.js`:
  - `createSurvey` now sets the `agentId` to the `userId` when the `userRole` is 'agent'.
  - `getSurveys` now fetches surveys where the `agentId` or `createdBy` ID matches your ID for agents.
  - `getSurveyById` now authorizes access for agents if the `createdBy` ID or the `agentId` matches your ID.