### PR TITLE
fix: Import tmp library to fix corrupted PDF reports

### DIFF
--- a/server/controllers/reports.js
+++ b/server/controllers/reports.js
@@ -4,6 +4,7 @@ import { PDFDocument, rgb, StandardFonts } from 'pdf-lib';
 import pptxgen from 'pptxgenjs';
 import Excel from 'exceljs';
 import fs from 'fs';
+import tmp from 'tmp';
 import Reporting from '../reporting/index.js';
 import Presentation from '../reporting/presentation.js';
 


### PR DESCRIPTION
The PDF generation for reports was failing due to a missing import of the `tmp` library. This resulted in a `ReferenceError` and corrupted PDF files.

This commit adds the necessary import statement to `server/controllers/reports.js` to resolve the issue.