### PR TITLE
fix: Populate dropdowns on user login

### DIFF
--- a/src/pages/Surveys.tsx
+++ b/src/pages/Surveys.tsx
@@ -135,7 +135,7 @@ const Surveys: React.FC = () => {
     };
 
     fetchAgentsAndCompanies();
-  }, []);
+  }, [user]);
 
   const handleAddSurvey = useCallback(async (e: React.FormEvent) => {
     e.preventDefault();


### PR DESCRIPTION
This commit fixes an issue where the company and project dropdowns were not being populated if you were not authenticated when the page first loaded.

The dependency array of the `useEffect` hook that fetches the companies and projects has been updated to include the `user` object. This ensures that the API calls are made whenever your authentication state changes.