### PR TITLE
fix: Handle undefined companyIds in EditSurvey

### DIFF
--- a/src/pages/EditSurvey.tsx
+++ b/src/pages/EditSurvey.tsx
@@ -11,6 +11,7 @@ interface SurveyFormData {
   questions: SurveyQuestion[];
   agentId?: string;
   companyIds?: string[];
+  projectId?: string;
 }
 
 const EditSurvey: React.FC = () => {
@@ -49,7 +50,7 @@ const EditSurvey: React.FC = () => {
           description: data.description,
           questions: data.questions || [],
           agentId: data.agentId,
-          companyIds: data.companyIds.map((id: any) => id.toString()),
+          companyIds: Array.isArray(data.companyIds) ? data.companyIds.map((id: any) => id.toString()) : [],
           projectId: data.projectId,
         });
       } catch (error) {


### PR DESCRIPTION
This commit fixes a 'Cannot read properties of undefined (reading 'map')' error that occurred when editing a survey.

The error was caused by calling the `.map` function on `data.companyIds` without first checking if it was an array. This has been resolved by adding a check to ensure that `data.companyIds` is an array before calling the `.map` function.