### PR TITLE
fix: Handle inconsistent data in EditSurvey

### DIFF
--- a/src/pages/EditSurvey.tsx
+++ b/src/pages/EditSurvey.tsx
@@ -48,7 +48,7 @@ const EditSurvey: React.FC = () => {
         setFormData({
           title: data.title,
           description: data.description,
-          questions: data.questions || [],
+          questions: Array.isArray(data.questions) ? data.questions : [],
           agentId: data.agentId,
           companyIds: Array.isArray(data.companyIds) ? data.companyIds.map((id: any) => id.toString()) : [],
           projectId: data.projectId,


### PR DESCRIPTION
This commit fixes an issue where the 'Edit' button was not working for some surveys.

The error was caused by calling the `.map` function on `data.questions` without first checking if it was an array. This has been resolved by adding a check to ensure that `data.questions` is an array before calling the `.map` function.