### PR TITLE
fix: Handle null surveys in ProjectDetails

### DIFF
--- a/src/pages/ProjectDetails.tsx
+++ b/src/pages/ProjectDetails.tsx
@@ -311,7 +311,7 @@ const ProjectDetails: React.FC = () => {
       </div>
 
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-        {surveys.map((survey) => (
+        {surveys.filter(survey => survey).map((survey) => (
           <Card key={survey.id} className="hover:shadow-lg transition-shadow">
             <CardContent className="p-6">
               <div className="flex justify-between items-start">


### PR DESCRIPTION
This commit fixes a 'Cannot read properties of null (reading 'id')' error that occurred on the project details page.

The error was caused by calling the `.map` function on the `surveys` array, which contained `null` values. This has been resolved by adding a filter to the `surveys.map` function to filter out any `null` values.