### PR TITLE
fix: Project and company selection dropdowns

### DIFF
--- a/src/pages/Surveys.tsx
+++ b/src/pages/Surveys.tsx
@@ -26,6 +26,7 @@ const Surveys: React.FC = () => {
     description: '',
     questions: [],
     projectId: '',
+    companyIds: [],
   });
   const { user } = useAuth();
   const navigate = useNavigate();
@@ -87,6 +88,7 @@ const Surveys: React.FC = () => {
       description: '',
       questions: [],
       projectId: '',
+      companyIds: [],
     });
   }, []);
 


### PR DESCRIPTION
This commit fixes an issue where the selected companies were not being saved when creating a new survey.

The `formData` state in `src/pages/Surveys.tsx` was not being correctly initialized with the `companyIds` field. This has been resolved by adding the `companyIds` field to the initial state and updating the `resetForm` function to reset the `companyIds` field.