### PR TITLE
fix: Correct download URL in frontend

### DIFF
--- a/src/pages/Reports.tsx
+++ b/src/pages/Reports.tsx
@@ -211,7 +211,7 @@ const Reports: React.FC = () => {
     }
 
     try {
-      const response = await fetch(`/api/reports/${report.id}?format=${format}`, {
+      const response = await fetch(`/api/reports/${report.id}/download?format=${format}`, {
         headers: {
           Authorization: `Bearer ${token}`,
         },


### PR DESCRIPTION
The download URL in the frontend was incorrect, which was causing the download request to be routed to the wrong controller function. This commit corrects the URL to ensure that the download request is routed to the correct controller function.

This should finally resolve the issue with the corrupted PDFs.