### PR TITLE
Fix: Display logo on landing page

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { Menu, Bell, ChevronRight } from 'lucide-react';
+import logo from '/logo.png';
 import { useAuth } from '../../context/AuthContext';
 import { Button } from '../ui/Button';
 import { useBreadcrumbs } from '../../hooks/useBreadcrumbs';
@@ -17,7 +18,7 @@ export const Header: React.FC<HeaderProps> = ({ onToggleSidebar }) => {
     <header className="bg-white border-b border-gray-200 sticky top-0 z-10 h-16 flex items-center justify-between px-4 md:px-6">
       <div className="flex items-center">
         <Link to="/" className="mr-4">
-          <img src="/logo.png" alt="Logo" className="h-8" />
+          <img src={logo} alt="Logo" className="h-8" />
         </Link>
         <Button
           variant="ghost"


### PR DESCRIPTION
The logo was not displaying on the landing page because the `Header.tsx` component was using a hardcoded path for the logo image. This commit updates the `Header.tsx` component to import the logo and use the imported variable, which is the same way the logo is displayed on the login page.

This ensures that the logo is displayed consistently across the application.