### PR TITLE
fix: Add redirect rule to netlify.toml

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,8 @@
 [build]
   command = "npm run build"
   publish = "dist"
+
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200


### PR DESCRIPTION
This commit adds a redirect rule to the `netlify.toml` file to ensure that all routes are handled by `index.html`. This is necessary for single-page applications to handle client-side routing correctly and should resolve the 'Page not found' error when you access routes directly.