### PR TITLE
fix: Configure Netlify proxy for API requests

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,6 +3,11 @@
   publish = "dist"
 
 [[redirects]]
+  from = "/api/*"
+  to = "https://sigmaplus-backend.onrender.com/api/:splat"
+  status = 200
+
+[[redirects]]
   from = "/*"
   to = "/index.html"
   status = 200


### PR DESCRIPTION
This commit configures a proxy rule in `netlify.toml` to redirect all API requests from `/api/*` to the backend server at `https://sigmaplus-backend.onrender.com/api/:splat`. This is necessary for the application to function correctly in a production environment, as the Vite proxy is only for local development. This change should resolve the login issues and 'Page not found' errors.