### PR TITLE
fix: Use environment variable for API base URL

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,11 +3,6 @@
   publish = "dist"
 
 [[redirects]]
-  from = "/api/*"
-  to = "https://sigmaplus-backend.onrender.com/api/:splat"
-  status = 200
-
-[[redirects]]
   from = "/*"
   to = "/index.html"
   status = 200

--- a/src/hooks/useApi.tsx
+++ b/src/hooks/useApi.tsx
@@ -7,7 +7,8 @@ const useApi = (logout: () => void) => {
       ...(token && { Authorization: `Bearer ${token}` }),
     };
 
-    const response = await fetch(`/api${url}`, { ...options, headers });
+    const baseUrl = import.meta.env.VITE_API_BASE_URL || '';
+    const response = await fetch(`${baseUrl}/api${url}`, { ...options, headers });
 
     if (response.status === 401) {
       logout();


### PR DESCRIPTION
This commit updates the `useApi` hook to use the `VITE_API_BASE_URL` environment variable for the backend URL. This allows the frontend to correctly identify the backend URL and resolves the login issues. The unnecessary proxy rule has been removed from `netlify.toml`.