### PR TITLE
feat: Protect routes to require login

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -124,10 +124,10 @@ const AppRoutes: React.FC = () => {
             <SurveyResponsePage />
           </ProtectedRoute>
         } />
-        <Route path="/market-research" element={<MarketResearch />} />
-        <Route path="/survey-builder" element={<SurveyBuilderPage />} />
-        <Route path="/advanced-analytics" element={<AdvancedAnalyticsPage />} />
-        <Route path="/collaboration" element={<CollaborationPage />} />
+        <Route path="/market-research" element={<ProtectedRoute><MarketResearch /></ProtectedRoute>} />
+        <Route path="/survey-builder" element={<ProtectedRoute><SurveyBuilderPage /></ProtectedRoute>} />
+        <Route path="/advanced-analytics" element={<ProtectedRoute><AdvancedAnalyticsPage /></ProtectedRoute>} />
+        <Route path="/collaboration" element={<ProtectedRoute><CollaborationPage /></ProtectedRoute>} />
         <Route path="/multi-survey-dashboard" element={
           <ProtectedRoute>
             <MultiSurveyAnalysis />


### PR DESCRIPTION
This change wraps several previously public routes with the `ProtectedRoute` component. This ensures that users must be authenticated before accessing these pages, redirecting them to the login screen if they are not.

The following routes are now protected:
- /market-research
- /survey-builder
- /advanced-analytics
- /collaboration

This addresses the issue where users could access parts of the application without being logged in.