### PR TITLE
fix(dashboard): Create missing DashboardCard component

### DIFF
--- a/src/components/dashboard/DashboardCard.tsx
+++ b/src/components/dashboard/DashboardCard.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '../ui/Card';
+import { Loader2 } from 'lucide-react';
+
+interface DashboardCardProps {
+  title: string;
+  isLoading: boolean;
+  children: React.ReactNode;
+  variant?: 'pie' | 'bar' | 'line';
+}
+
+export const DashboardCard: React.FC<DashboardCardProps> = ({ title, isLoading, children }) => {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{title}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <div className="flex justify-center items-center h-64">
+            <Loader2 className="h-8 w-8 animate-spin text-gray-500" />
+          </div>
+        ) : (
+          children
+        )}
+      </CardContent>
+    </Card>
+  );
+};


### PR DESCRIPTION
The component `src/components/dashboard/DashboardCard.tsx` was missing, causing a build error in `DashboardModule.tsx`.

This commit adds the `DashboardCard` component back. It's a simple wrapper component that displays a title, a loading indicator, and its children. This resolves the build error and allows the dashboard to render correctly.