### PR TITLE
Refactor header navigation links

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -22,10 +22,10 @@ const Header: React.FC = () => {
           <nav className="hidden md:flex space-x-4">
             <NavLink to="/dashboard">Dashboard</NavLink>
             <NavLink to="/projects">Projects</NavLink>
-            <NavLink to="/reports">Reports</NavLink>
             <NavLink to="/market-research">Market Research</NavLink>
             <NavLink to="/survey-builder">Survey Builder</NavLink>
             <NavLink to="/advanced-analytics">Advanced Analytics</NavLink>
+            <NavLink to="/reports">Reports</NavLink>
             <NavLink to="/collaboration">Collaboration</NavLink>
             <NavLink to="/multi-survey-dashboard">Multi-Survey Analysis</NavLink>
             {user?.role === 'admin' && (


### PR DESCRIPTION
- Remove 'Surveys' link from the top navigation bar.
- Move 'Reports' link to be after 'Advanced Analytics'.