### PR TITLE
feat: Populate dashboard with dummy data

### DIFF
--- a/jules-scratch/verification/verify_dashboard.py
+++ b/jules-scratch/verification/verify_dashboard.py
@@ -1,0 +1,38 @@
+import asyncio
+from playwright.async_api import async_playwright, expect
+
+async def main():
+    async with async_playwright() as p:
+        browser = await p.chromium.launch(headless=True)
+        page = await browser.new_page()
+
+        # Navigate to the registration page
+        await page.goto("http://localhost:5173/register")
+
+        # Generate a unique email for registration
+        import random
+        import string
+        random_string = ''.join(random.choices(string.ascii_lowercase + string.digits, k=10))
+        email = f"testuser_{random_string}@example.com"
+        password = "Password123"
+
+        # Fill out the registration form
+        await page.get_by_label("Name").fill("Test User")
+        await page.get_by_label("Email").fill(email)
+        await page.get_by_label("Password").fill(password)
+        await page.get_by_label("Role").select_option("admin")
+
+        # Click the register button
+        await page.get_by_role("button", name="Register").click()
+
+        # Wait for navigation to the dashboard or a redirect to login
+        # After registration, the user is automatically logged in and redirected to the dashboard
+        await expect(page).to_have_url("http://localhost:5173/dashboard", timeout=10000)
+
+        # Take a screenshot of the dashboard
+        await page.screenshot(path="jules-scratch/verification/dashboard.png")
+
+        await browser.close()
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/server/controllers/reports.js
+++ b/server/controllers/reports.js
@@ -95,6 +95,41 @@ export const generateReport = async (req, res) => {
 // @route   GET /api/reports
 // @access  Private (Admins, Agents, Clients)
 export const getReports = async (req, res) => {
+  const useDummyData = true; // Set to true to use dummy data
+
+  if (useDummyData) {
+    const dummyReports = [
+      {
+        _id: new ObjectId(),
+        title: 'Q1 2024 Customer Satisfaction Report',
+        surveyId: new ObjectId(),
+        companyId: new ObjectId(),
+        generatedBy: new ObjectId(),
+        createdAt: new Date('2024-04-05T10:00:00Z'),
+        status: 'completed',
+      },
+      {
+        _id: new ObjectId(),
+        title: 'Product Launch Feedback Analysis',
+        surveyId: new ObjectId(),
+        companyId: new ObjectId(),
+        generatedBy: new ObjectId(),
+        createdAt: new Date('2024-03-20T14:30:00Z'),
+        status: 'completed',
+      },
+      {
+        _id: new ObjectId(),
+        title: 'Annual Employee Engagement Survey Results',
+        surveyId: new ObjectId(),
+        companyId: new ObjectId(),
+        generatedBy: new ObjectId(),
+        createdAt: new Date('2024-02-15T11:00:00Z'),
+        status: 'completed',
+      },
+    ];
+    return res.json({ data: dummyReports });
+  }
+
   try {
     const db = getDb();
     const reportsCollection = db.collection('reports');

--- a/src/hooks/useDashboardStats.ts
+++ b/src/hooks/useDashboardStats.ts
@@ -24,12 +24,41 @@ export const useDashboardStats = () => {
   const isAdmin = user?.role === UserRole.ADMIN;
   const isClient = user?.role === UserRole.CLIENT;
 
+  const useDummyData = true; // Set to true to use dummy data
+
   useEffect(() => {
     const fetchDashboardData = async () => {
       if (!user) return;
 
       setIsLoading(true);
       setError(null);
+
+      if (useDummyData) {
+        const dummyStats: DashboardStats = {
+          totalSurveys: 50,
+          totalResponses: 1250,
+          reportsGenerated: 25,
+          averageCompletionRate: 85,
+          totalUsers: isAdmin ? 100 : undefined,
+          totalCompanies: 20,
+          surveyStatusDistribution: [
+            { status: 'active', count: 20 },
+            { status: 'draft', count: 10 },
+            { status: 'completed', count: 15 },
+            { status: 'archived', count: 5 },
+          ],
+          responsesBySurvey: [
+            { title: 'Customer Satisfaction Q1', responseCount: 300 },
+            { title: 'Product Feedback Q1', responseCount: 250 },
+            { title: 'Employee Engagement 2024', responseCount: 400 },
+            { title: 'Market Research: New Logo', responseCount: 150 },
+            { title: 'Website Usability Study', responseCount: 150 },
+          ],
+        };
+        setStats(dummyStats);
+        setIsLoading(false);
+        return;
+      }
 
       try {
         const [
@@ -82,7 +111,7 @@ export const useDashboardStats = () => {
     };
 
     fetchDashboardData();
-  }, [user, api, isAdmin, isClient]);
+  }, [user, api, isAdmin, isClient, useDummyData]);
 
   return { stats, isLoading, error };
 };


### PR DESCRIPTION
This commit populates the dashboard with dummy data for statistics and survey reports.

- A `useDummyData` flag has been added to `src/hooks/useDashboardStats.ts` to control the display of dummy statistics on the dashboard. When enabled, the hook returns a hardcoded set of stats.
- The `getReports` function in `server/controllers/reports.js` has been updated to return a list of dummy survey reports when the `useDummyData` flag is enabled.

This change is intended to provide a populated dashboard for development and demonstration purposes until real data is available.