### PR TITLE
Fix(auth): Handle JWT expiration and refresh race conditions

### DIFF
--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -1,6 +1,5 @@
 import React, { createContext, useContext, useState, useEffect } from 'react';
 import { User } from '../types';
-import useApi from '../hooks/useApi';
 
 interface AuthContextType {
   user: User | null;
@@ -13,7 +12,7 @@ interface AuthContextType {
 
 export const AuthContext = createContext<AuthContextType>({
   user: null,
-  isLoading: false,
+  isLoading: true, // Start with loading true
   login: async () => {},
   logout: () => {},
   setAuthToken: () => {},
@@ -31,7 +30,6 @@ export const useAuth = () => {
 export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [user, setUser] = useState<User | null>(null);
   const [isLoading, setIsLoading] = useState(true);
-  const api = useApi();
 
   const setAuthToken = (token: string) => {
     localStorage.setItem('authToken', token);
@@ -41,6 +39,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     setUser(null);
     localStorage.removeItem('user');
     localStorage.removeItem('authToken');
+    // Consider using useNavigate for SPA-style navigation
     window.location.href = '/login';
   };
 
@@ -51,22 +50,29 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       try {
         const savedUser = JSON.parse(savedUserString);
         setUser(savedUser);
-        setAuthToken(token);
       } catch (e) {
         console.error("Error parsing saved user from localStorage", e);
-        logout();
+        logout(); // Clear corrupted data
       }
     }
     setIsLoading(false);
   }, []);
 
-  const login = async (email: string, password:string) => {
+  const login = async (email: string, password: string) => {
     setIsLoading(true);
     try {
-      const data = await api('/auth/login', {
+      const baseUrl = import.meta.env.VITE_API_BASE_URL || '';
+      const response = await fetch(`${baseUrl}/api/auth/login`, {
         method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ email, password }),
       });
+
+      const data = await response.json();
+
+      if (!response.ok) {
+        throw new Error(data.message || 'Login failed');
+      }
       
       if (data.token && data.user) {
         setUser(data.user);
@@ -77,6 +83,8 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       }
     } catch (error: any) {
       console.error('Login API error:', error);
+      // Clear any partial login artifacts
+      logout();
       throw error;
     } finally {
       setIsLoading(false);

--- a/src/hooks/useApi.tsx
+++ b/src/hooks/useApi.tsx
@@ -1,69 +1,83 @@
 import { useContext } from 'react';
-import { AuthContext } from '../context/AuthContext'; // Assuming AuthContext is exported
+import { AuthContext } from '../context/AuthContext';
+
+// Shared state to prevent race conditions with token refreshing
+let refreshTokenPromise: Promise<string> | null = null;
 
 const useApi = () => {
   const { logout, setAuthToken } = useContext(AuthContext);
 
+  const handleRefreshToken = async () => {
+    try {
+      const currentToken = localStorage.getItem('authToken');
+      const baseUrl = import.meta.env.VITE_API_BASE_URL || '';
+
+      const response = await fetch(`${baseUrl}/api/auth/refresh`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${currentToken}`,
+        },
+      });
+
+      if (!response.ok) {
+        throw new Error('Failed to refresh token');
+      }
+
+      const data = await response.json();
+      if (data.token) {
+        setAuthToken(data.token);
+        refreshTokenPromise = null; // Clear the promise on success
+        return data.token;
+      } else {
+        throw new Error('No new token received');
+      }
+    } catch (error) {
+      logout(); // Logout user on refresh failure
+      refreshTokenPromise = null; // Clear the promise on failure
+      throw error;
+    }
+  };
+
   const apiFetch = async (url: string, options: RequestInit = {}) => {
     let token = localStorage.getItem('authToken');
 
-    const makeRequest = async () => {
+    const makeRequest = async (): Promise<any> => {
       const headers = {
-        ...options.headers,
         'Content-Type': 'application/json',
+        ...options.headers,
         ...(token && { Authorization: `Bearer ${token}` }),
       };
 
       const baseUrl = import.meta.env.VITE_API_BASE_URL || '';
       const response = await fetch(`${baseUrl}/api${url}`, { ...options, headers });
 
-      if (!response.ok) {
-        if (response.status === 401) {
-          // Token is invalid or expired, try to refresh it
-          try {
-            const newToken = await refreshToken();
-            token = newToken; // Update token for the retry
-            // Retry the original request with the new token
-            return makeRequest();
-          } catch (refreshError) {
-            // If refresh fails, logout the user
-            logout();
-            throw new Error('Session expired. Please log in again.');
-          }
+      if (response.status !== 401) {
+        if (!response.ok) {
+          // Handle non-401 errors
+          const errorData = await response.json().catch(() => ({ message: 'An unknown error occurred' }));
+          throw new Error(errorData.message || 'An error occurred');
         }
-        const errorData = await response.json();
-        throw new Error(errorData.message || 'An error occurred');
+        return response.json();
       }
-      return response.json();
+
+      // Handle 401 Unauthorized error: token needs refresh
+      if (!refreshTokenPromise) {
+        refreshTokenPromise = handleRefreshToken();
+      }
+
+      try {
+        const newToken = await refreshTokenPromise;
+        token = newToken;
+        // Retry the original request with the new token
+        return makeRequest();
+      } catch (error) {
+        // This will be caught if handleRefreshToken throws an error
+        throw new Error('Session expired. Please log in again.');
+      }
     };
 
     return makeRequest();
-  };
-
-  const refreshToken = async () => {
-    const currentToken = localStorage.getItem('authToken');
-    const baseUrl = import.meta.env.VITE_API_BASE_URL || '';
-
-    const response = await fetch(`${baseUrl}/api/auth/refresh`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${currentToken}`,
-      },
-    });
-
-
-    if (!response.ok) {
-      throw new Error('Failed to refresh token');
-    }
-
-    const data = await response.json();
-    if (data.token) {
-      setAuthToken(data.token); // Update token in context and local storage
-      return data.token;
-    } else {
-      throw new Error('No new token received');
-    }
   };
 
   return apiFetch;


### PR DESCRIPTION
This commit addresses a recurring 'jwt expired' error by improving the authentication flow on the frontend.

The primary issue was a race condition in the token refresh mechanism. When multiple API requests were made simultaneously with an expired token, each would attempt to refresh the token, leading to conflicts and failed requests. This has been resolved by implementing a locking mechanism in `useApi.tsx` that ensures only one refresh request is active at a time.

Additionally, a circular dependency between `AuthContext.tsx` and `useApi.tsx` has been removed. The `login` function in `AuthProvider` now uses a direct `fetch` call instead of the `useApi` hook, as the complex logic of the hook is unnecessary for the initial login.