### PR TITLE
fix(dashboard): Import StatCard and Card components

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import StatCard from '../components/dashboard/StatCard';
+import { Card, CardContent, CardHeader, CardTitle } from '../components/ui/Card';
 import { Users, BarChart3, ClipboardList, TrendingUp, Building2, UserCheck } from 'lucide-react';
 import { useAuth } from '../context/AuthContext';
 import { useDashboardStats } from '../hooks/useDashboardStats';


### PR DESCRIPTION
Resolves a `ReferenceError: StatCard is not defined` by importing the `StatCard` component in `src/pages/Dashboard.tsx`.

Also, this change imports the `Card`, `CardContent`, `CardHeader`, and `CardTitle` components that were being used without being imported.