### PR TITLE
refactor: Centralize API calls to use `useApi` hook

### DIFF
--- a/src/components/surveys/SurveysList.tsx
+++ b/src/components/surveys/SurveysList.tsx
@@ -6,6 +6,7 @@ import { Card, CardContent } from '../ui/Card';
 import { Modal } from '../ui/Modal';
 import { useAuth } from '../../context/AuthContext';
 import { useNavigate } from 'react-router-dom';
+import useApi from '../../hooks/useApi';
 
 interface Survey {
   id: string;
@@ -25,6 +26,7 @@ const SurveysList: React.FC = () => {
   });
   const { user } = useAuth();
   const navigate = useNavigate();
+  const apiFetch = useApi();
   const [apiError, setApiError] = useState<string | null>(null);
 
   const triggerRefetch = () => {
@@ -41,40 +43,21 @@ const SurveysList: React.FC = () => {
   const fetchData = useCallback(async () => {
     setIsLoading(true);
     setApiError(null);
-    const token = localStorage.getItem('authToken');
-
-    if (!token) {
-      setApiError("No authentication token found. Please login.");
-      setIsLoading(false);
-      setSurveys([]);
-      return;
-    }
-
     try {
-      const surveysResponse = await fetch('/api/surveys', {
-        headers: { 'Authorization': `Bearer ${token}` },
-      });
-
-      if (!surveysResponse.ok) {
-        const errorData = await surveysResponse.json().catch(() => ({}));
-        throw new Error(errorData.msg || errorData.error || `HTTP error! status: ${surveysResponse.status}`);
-      }
-
-      const surveysResult = await surveysResponse.json();
+      const surveysResult = await apiFetch('/surveys');
       const fetchedSurveys = (surveysResult.data || []).map((s: Record<string, unknown>) => ({
         ...s,
         id: s._id,
         createdAt: s.createdAt || new Date().toISOString(),
       }));
       setSurveys(fetchedSurveys as Survey[]);
-
-    } catch (error) {
-      if (!apiError) setApiError((error as Error).message || 'Failed to fetch data from API.');
+    } catch (error: any) {
+      setApiError(error.message || 'Failed to fetch data from API.');
       setSurveys([]);
     } finally {
       setIsLoading(false);
     }
-  }, [apiError]);
+  }, [apiFetch]);
 
   useEffect(() => {
     fetchData();
@@ -83,11 +66,6 @@ const SurveysList: React.FC = () => {
   const handleAddSurvey = useCallback(async (e: React.FormEvent) => {
     e.preventDefault();
     setApiError(null);
-    const token = localStorage.getItem('authToken');
-    if (!token) {
-      setApiError("Authentication required. Please login.");
-      return;
-    }
 
     if (!formData.title.trim()) {
       setApiError("Survey title is required.");
@@ -95,56 +73,31 @@ const SurveysList: React.FC = () => {
     }
 
     try {
-      const response = await fetch('/api/surveys', {
+      await apiFetch('/surveys', {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${token}`,
-        },
         body: JSON.stringify(formData),
       });
-
-      if (!response.ok) {
-        const errorData = await response.json().catch(() => ({}));
-        throw new Error(errorData.errors?.[0]?.msg || errorData.error || errorData.msg || `Failed to create survey: ${response.statusText}`);
-      }
 
       setIsAddModalOpen(false);
       resetForm();
       triggerRefetch();
-    } catch (error) {
-      setApiError((error as Error).message || 'An unexpected error occurred while adding the survey.');
+    } catch (error: any) {
+      setApiError(error.message || 'An unexpected error occurred while adding the survey.');
     }
-  }, [formData, resetForm, triggerRefetch]);
+  }, [formData, resetForm, triggerRefetch, apiFetch]);
 
   const handleDelete = async (surveyId: string) => {
     if (!window.confirm('Are you sure you want to delete this survey?')) {
       return;
     }
-
     setApiError(null);
-    const token = localStorage.getItem('authToken');
-    if (!token) {
-      setApiError("Authentication required. Please login.");
-      return;
-    }
-
     try {
-      const response = await fetch(`/api/surveys/${surveyId}`, {
+      await apiFetch(`/surveys/${surveyId}`, {
         method: 'DELETE',
-        headers: {
-          'Authorization': `Bearer ${token}`,
-        },
       });
-
-      if (!response.ok) {
-        const errorData = await response.json().catch(() => ({}));
-        throw new Error(errorData.msg || errorData.error || `Failed to delete survey: ${response.statusText}`);
-      }
-
       triggerRefetch();
-    } catch (error) {
-      setApiError((error as Error).message || 'An unexpected error occurred while deleting the survey.');
+    } catch (error: any) {
+      setApiError(error.message || 'An unexpected error occurred while deleting the survey.');
     }
   };
 

--- a/src/pages/Companies.tsx
+++ b/src/pages/Companies.tsx
@@ -5,6 +5,7 @@ import { Input } from '../components/ui/Input';
 import { Card, CardContent } from '../components/ui/Card';
 import { Modal } from '../components/ui/Modal';
 import { useAuth } from '../context/AuthContext';
+import useApi from '../hooks/useApi';
 
 interface Company {
   id: string;
@@ -119,6 +120,7 @@ const Companies: React.FC = () => {
     employeeCount: 0
   });
   const { user: loggedInUser } = useAuth();
+  const apiFetch = useApi();
   const [apiError, setApiError] = useState<string | null>(null);
 
   // Moved resetForm to the top, before other functions that might use it
@@ -142,53 +144,23 @@ const Companies: React.FC = () => {
   // Optimized fetchCompanies useCallback
   const fetchCompanies = useCallback(async () => {
     setIsLoading(true);
-    setApiError(null); // Clear any previous API errors at the start of a new fetch attempt
-    const token = localStorage.getItem('authToken');
-
-    if (!token) {
-      setApiError("No authentication token found. Please login.");
-      setIsLoading(false);
-      setCompanies([]);
-      return;
-    }
-
+    setApiError(null);
     try {
-      const response = await fetch('/api/companies', {
-        headers: {
-          'Authorization': `Bearer ${token}`,
-        },
-      });
-
-      if (!response.ok) {
-        let errorMsg = `Error fetching companies: ${response.statusText}`;
-        if (response.status === 401 || response.status === 403) {
-          try {
-            const errorData = await response.json();
-            errorMsg = errorData.msg || errorData.error || errorMsg;
-          } catch (e) { /* ignore if error response not json */ }
-        }
-        setApiError(errorMsg);
-        throw new Error(`HTTP error! status: ${response.status}`);
-      }
-
-      const result = await response.json();
+      const result = await apiFetch('/companies');
       const fetchedCompanies = (result.data || []).map((c: any) => ({
         ...c,
         id: c._id,
         logo: c.logo || `https://ui-avatars.com/api/?name=${encodeURIComponent(c.name)}&background=random`,
       }));
       setCompanies(fetchedCompanies);
-    } catch (error) {
+    } catch (error: any) {
       console.error('Error fetching companies from API:', error);
-      // Only set the error if it hasn't been set by the response.ok check above
-      if (!apiError) { // Check if apiError is null before setting a generic message
-        setApiError('Failed to fetch companies. Please try again.');
-      }
+      setApiError(error.message || 'Failed to fetch companies. Please try again.');
       setCompanies([]);
     } finally {
       setIsLoading(false);
     }
-  }, [loggedInUser]); // Correct dependencies: only depends on loggedInUser
+  }, [apiFetch]);
 
   // Simplified useEffect for initial data fetch
   useEffect(() => {
@@ -203,14 +175,8 @@ const Companies: React.FC = () => {
 
   const handleAddCompany = useCallback(async (e: React.FormEvent) => {
     e.preventDefault();
-    setApiError(null); // Clear previous errors
-    const token = localStorage.getItem('authToken');
-    if (!token) {
-      setApiError("Authentication required.");
-      return;
-    }
+    setApiError(null);
 
-    // Basic frontend validation (backend will also validate)
     if (!formData.name.trim() || !formData.email.trim() || !formData.phone.trim() || !formData.address.trim()) {
       setApiError("Name, Email, Phone, and Address are required.");
       return;
@@ -221,22 +187,10 @@ const Companies: React.FC = () => {
     }
 
     try {
-      const response = await fetch('/api/companies', {
+      await apiFetch('/companies', {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${token}`,
-        },
-        body: JSON.stringify(formData), // Send all formData
+        body: JSON.stringify(formData),
       });
-
-      if (!response.ok) {
-        const errorData = await response.json().catch(() => ({}));
-        throw new Error(errorData.errors?.[0]?.msg || errorData.error || errorData.msg || `Failed to add company: ${response.statusText}`);
-      }
-
-      // Instead of relying on the API response for the new company data,
-      // re-fetch the entire list to ensure consistency and proper IDs from the backend.
       await fetchCompanies();
       setIsAddModalOpen(false);
       resetForm();
@@ -244,7 +198,7 @@ const Companies: React.FC = () => {
       console.error('Error adding company via API:', error);
       setApiError(error.message || 'An unexpected error occurred while adding the company.');
     }
-  }, [formData, resetForm, fetchCompanies]); // Dependencies are correct
+  }, [formData, resetForm, fetchCompanies, apiFetch]);
 
   const handleEditCompany = useCallback(async (e: React.FormEvent) => {
     e.preventDefault();
@@ -252,14 +206,8 @@ const Companies: React.FC = () => {
       setApiError("No company selected for editing or company ID is missing.");
       return;
     }
-    setApiError(null); // Clear previous errors
-    const token = localStorage.getItem('authToken');
-    if (!token) {
-      setApiError("Authentication required.");
-      return;
-    }
+    setApiError(null);
 
-    // Basic frontend validation (backend will also validate)
     if (!formData.name.trim() || !formData.email.trim() || !formData.phone.trim() || !formData.address.trim()) {
       setApiError("Name, Email, Phone, and Address are required for editing.");
       return;
@@ -270,21 +218,10 @@ const Companies: React.FC = () => {
     }
 
     try {
-      const response = await fetch(`/api/companies/${editingCompany.id}`, {
+      await apiFetch(`/companies/${editingCompany.id}`, {
         method: 'PUT',
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${token}`,
-        },
-        body: JSON.stringify(formData), // Send all formData for update
+        body: JSON.stringify(formData),
       });
-
-      if (!response.ok) {
-        const errorData = await response.json().catch(() => ({}));
-        throw new Error(errorData.errors?.[0]?.msg || errorData.error || errorData.msg || `Failed to update company: ${response.statusText}`);
-      }
-
-      // Re-fetch the companies list to ensure consistency after an update.
       await fetchCompanies();
       setIsEditModalOpen(false);
       resetForm();
@@ -292,20 +229,13 @@ const Companies: React.FC = () => {
       console.error('Error updating company via API:', error);
       setApiError(error.message || 'An unexpected error occurred while updating the company.');
     }
-  }, [formData, editingCompany, resetForm, fetchCompanies]); // Dependencies are correct
+  }, [formData, editingCompany, resetForm, fetchCompanies, apiFetch]);
 
   const handleToggleCompanyStatus = useCallback(async (companyId: string, currentStatus: 'active' | 'inactive') => {
-    setApiError(null); // Clear previous errors
-    const token = localStorage.getItem('authToken');
-    if (!token) {
-      setApiError("Authentication required.");
-      return;
-    }
-
+    setApiError(null);
     const newStatus = currentStatus === 'active' ? 'inactive' : 'active';
     const originalCompanies = [...companies];
 
-    // Optimistic UI update
     setCompanies(prevCompanies =>
       prevCompanies.map(c =>
         c.id === companyId ? { ...c, status: newStatus } : c
@@ -313,43 +243,17 @@ const Companies: React.FC = () => {
     );
 
     try {
-      const response = await fetch(`/api/companies/${companyId}`, {
+      await apiFetch(`/companies/${companyId}`, {
         method: 'PUT',
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${token}`,
-        },
-        body: JSON.stringify({ status: newStatus }), // Only send the status to update
+        body: JSON.stringify({ status: newStatus }),
       });
-
-      if (!response.ok) {
-        const errorData = await response.json().catch(() => ({}));
-        setCompanies(originalCompanies); // Revert optimistic update
-        throw new Error(errorData.errors?.[0]?.msg || errorData.error || errorData.msg || `Failed to update company status: ${response.statusText}`);
-      }
-
-      // If the API confirms the update, no need to re-fetch the entire list
-      // if the backend response gives the updated company.
-      // However, re-fetching is safer to guarantee full consistency if backend logic is complex.
-      // For simplicity and robustness, staying with a re-fetch for now.
-      await fetchCompanies(); // Re-fetch to ensure full consistency, especially if backend has other side effects
-      // OR: update state with the response for slight optimization if you trust backend response fully:
-      // const updatedCompanyFromApi = await response.json();
-      // const finalUpdatedCompany = {
-      //   ...(updatedCompanyFromApi.data || updatedCompanyFromApi),
-      //   id: (updatedCompanyFromApi.data || updatedCompanyFromApi)._id,
-      //   logo: (updatedCompanyFromApi.data || updatedCompanyFromApi).logo || `https://ui-avatars.com/api/?name=${encodeURIComponent((updatedCompanyFromApi.data || updatedCompanyFromApi).name)}&background=random`
-      // };
-      // setCompanies(prevCompanies =>
-      //   prevCompanies.map(c => (c.id === finalUpdatedCompany.id ? { ...c, ...finalUpdatedCompany } : c))
-      // );
-
+      await fetchCompanies();
     } catch (error: any) {
       console.error('Error updating company status via API:', error);
       setApiError(error.message || 'An unexpected error occurred while updating company status.');
-      setCompanies(originalCompanies); // Ensure reversion on any catch
+      setCompanies(originalCompanies);
     }
-  }, [companies, fetchCompanies]); // `companies` for optimistic update, `fetchCompanies` for refetch
+  }, [companies, fetchCompanies, apiFetch]);
 
   const startEdit = useCallback((company: Company) => {
     setEditingCompany(company);

--- a/src/pages/EditReportSections.tsx
+++ b/src/pages/EditReportSections.tsx
@@ -2,27 +2,19 @@ import React, { useState, useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 import { Report as ReportType, Section } from '../types';
 import { Button } from '../components/ui/Button';
-import { Input } from '../components/ui/Input';
+import useApi from '../hooks/useApi';
 
 const EditReportSections: React.FC = () => {
   const { id } = useParams<{ id: string }>();
   const [report, setReport] = useState<ReportType | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const apiFetch = useApi();
 
   useEffect(() => {
     const fetchReport = async () => {
       try {
-        const token = localStorage.getItem('authToken');
-        const response = await fetch(`/api/reports/${id}`, {
-          headers: {
-            'Authorization': `Bearer ${token}`,
-          },
-        });
-        if (!response.ok) {
-          throw new Error('Failed to fetch report');
-        }
-        const data = await response.json();
+        const data = await apiFetch(`/reports/${id}`);
         setReport(data.data);
       } catch (err: any) {
         setError(err.message);
@@ -32,7 +24,7 @@ const EditReportSections: React.FC = () => {
     };
 
     fetchReport();
-  }, [id]);
+  }, [id, apiFetch]);
 
   const handleSectionChange = (sectionIndex: number, subSectionIndex: number, value: string) => {
     if (report) {
@@ -46,18 +38,10 @@ const EditReportSections: React.FC = () => {
   const handleSaveChanges = async () => {
     if (report) {
       try {
-        const token = localStorage.getItem('authToken');
-        const response = await fetch(`/api/reports/${id}`, {
+        await apiFetch(`/reports/${id}`, {
           method: 'PUT',
-          headers: {
-            'Content-Type': 'application/json',
-            'Authorization': `Bearer ${token}`,
-          },
           body: JSON.stringify({ sections: report.sections }),
         });
-        if (!response.ok) {
-          throw new Error('Failed to save changes');
-        }
         alert('Changes saved successfully!');
       } catch (err: any) {
         setError(err.message);

--- a/src/pages/EditSurvey.tsx
+++ b/src/pages/EditSurvey.tsx
@@ -4,6 +4,7 @@ import { useAuth } from '../context/AuthContext';
 import { SurveyQuestion } from '../types';
 import SurveyForm from '../components/surveys/SurveyForm';
 import { Card, CardContent, CardHeader, CardTitle } from '../components/ui/Card';
+import useApi from '../hooks/useApi';
 
 interface SurveyFormData {
   title: string;
@@ -20,6 +21,7 @@ const EditSurvey: React.FC = () => {
   const [apiError, setApiError] = useState<string | null>(null);
   const { user } = useAuth();
   const navigate = useNavigate();
+  const apiFetch = useApi();
   const [agents, setAgents] = useState<Record<string, unknown>[]>([]);
   const [companies, setCompanies] = useState<Record<string, unknown>[]>([]);
   const [surveys, setSurveys] = useState<Record<string, unknown>[]>([]);
@@ -28,23 +30,8 @@ const EditSurvey: React.FC = () => {
   useEffect(() => {
     const fetchSurvey = async () => {
       setIsLoading(true);
-      const token = localStorage.getItem('authToken');
-      if (!token) {
-        setApiError("Authentication required.");
-        setIsLoading(false);
-        return;
-      }
-
       try {
-        const response = await fetch(`/api/surveys/${surveyId}`, {
-          headers: { 'Authorization': `Bearer ${token}` },
-        });
-
-        if (!response.ok) {
-          throw new Error('Failed to fetch survey data.');
-        }
-
-        const { data } = await response.json();
+        const { data } = await apiFetch(`/surveys/${surveyId}`);
         setFormData({
           title: data.title,
           description: data.description,
@@ -52,72 +39,53 @@ const EditSurvey: React.FC = () => {
           agentId: data.agentId,
           companyIds: data.companyIds,
         });
-      } catch (error) {
-        setApiError((error as Error).message);
+      } catch (error: any) {
+        setApiError(error.message);
       } finally {
         setIsLoading(false);
       }
     };
 
     fetchSurvey();
-  }, [surveyId]);
+  }, [surveyId, apiFetch]);
 
   useEffect(() => {
     const fetchRelatedData = async () => {
-      const token = localStorage.getItem('authToken');
-      if (!token) return;
-
       try {
-        const [agentsRes, companiesRes, surveysRes, projectsRes] = await Promise.all([
-          fetch('/api/users?role=agent', { headers: { 'Authorization': `Bearer ${token}` } }),
-          fetch('/api/companies', { headers: { 'Authorization': `Bearer ${token}` } }),
-          fetch('/api/surveys', { headers: { 'Authorization': `Bearer ${token}` } }),
-          fetch('/api/projects', { headers: { 'Authorization': `Bearer ${token}` } }),
+        const [agentsData, companiesData, surveysData, projectsData] = await Promise.all([
+          apiFetch('/users?role=agent'),
+          apiFetch('/companies'),
+          apiFetch('/surveys'),
+          apiFetch('/projects'),
         ]);
 
-        if (agentsRes.ok) setAgents((await agentsRes.json()).data || []);
-        if (companiesRes.ok) setCompanies((await companiesRes.json()).data || []);
-        if (surveysRes.ok) setSurveys((await surveysRes.json()).data || []);
-        if (projectsRes.ok) setProjects((await projectsRes.json()).data || []);
+        setAgents(agentsData.data || []);
+        setCompanies(companiesData.data || []);
+        setSurveys(surveysData.data || []);
+        setProjects(projectsData.data || []);
       } catch (error) {
         console.error("Failed to fetch related data:", error);
       }
     };
 
     fetchRelatedData();
-  }, []);
+  }, [apiFetch]);
 
   const handleFormSubmit = useCallback(async (e: React.FormEvent) => {
     e.preventDefault();
     if (!formData) return;
 
     setApiError(null);
-    const token = localStorage.getItem('authToken');
-    if (!token) {
-      setApiError("Authentication required.");
-      return;
-    }
-
     try {
-      const response = await fetch(`/api/surveys/${surveyId}`, {
+      await apiFetch(`/surveys/${surveyId}`, {
         method: 'PUT',
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${token}`,
-        },
         body: JSON.stringify(formData),
       });
-
-      if (!response.ok) {
-        const errorData = await response.json();
-        throw new Error(errorData.message || 'Failed to update survey.');
-      }
-
       navigate(`/surveys/${surveyId}`);
-    } catch (error) {
-      setApiError((error as Error).message);
+    } catch (error: any) {
+      setApiError(error.message);
     }
-  }, [formData, surveyId, navigate]);
+  }, [formData, surveyId, navigate, apiFetch]);
 
   if (isLoading) return <div>Loading...</div>;
   if (apiError) return <div className="text-red-500">{apiError}</div>;

--- a/src/pages/ProjectDetails.tsx
+++ b/src/pages/ProjectDetails.tsx
@@ -8,6 +8,7 @@ import { useAuth } from '../context/AuthContext';
 import { Survey, SurveyQuestion } from '../types';
 import SurveyForm from '../components/surveys/SurveyForm';
 import EditProjectModal from '../components/projects/EditProjectModal';
+import useApi from '../hooks/useApi';
 
 interface Project {
   id: string;
@@ -40,6 +41,7 @@ const ProjectDetails: React.FC = () => {
   });
   const { user } = useAuth();
   const navigate = useNavigate();
+  const apiFetch = useApi();
   const [apiError, setApiError] = useState<string | null>(null);
   const [agents, setAgents] = useState<any[]>([]);
   const [companies, setCompanies] = useState<any[]>([]);
@@ -59,121 +61,59 @@ const ProjectDetails: React.FC = () => {
     });
   }, [projectId]);
 
-  const fetchProjectAndSurveys = async () => {
+  const fetchProjectAndSurveys = useCallback(async () => {
     setIsLoading(true);
     setApiError(null);
-    const token = localStorage.getItem('authToken');
-
-    if (!token) {
-      setApiError("No authentication token found. Please login.");
-      setIsLoading(false);
-      return;
-    }
-
     try {
-      // Fetch project details
-      const projectResponse = await fetch(`/api/projects/${projectId}`, {
-        headers: {
-          'Authorization': `Bearer ${token}`,
-        },
-      });
-
-      if (!projectResponse.ok) {
-        const errorData = await projectResponse.json().catch(() => ({}));
-        setApiError(errorData.msg || errorData.error || `HTTP error! status: ${projectResponse.status}`);
-        setIsLoading(false);
-        return;
-      }
-
-      const projectResult = await projectResponse.json();
+      const projectResult = await apiFetch(`/projects/${projectId}`);
       setProject({ ...projectResult.data, id: projectResult.data._id });
 
-      // Fetch surveys for the project
-      const surveyResponse = await fetch(`/api/surveys?projectId=${projectId}`, {
-        headers: {
-          'Authorization': `Bearer ${token}`,
-        },
-      });
-
-      if (!surveyResponse.ok) {
-        const errorData = await surveyResponse.json().catch(() => ({}));
-        setApiError(errorData.msg || errorData.error || `HTTP error! status: ${surveyResponse.status}`);
-      } else {
-        const surveyResult = await surveyResponse.json();
-        const fetchedSurveys = (surveyResult.data || []).map((s: any) => ({
-          ...s,
-          id: s._id,
-          createdAt: s.createdAt || new Date().toISOString(),
-          responseCount: s.responseCount || 0,
-          status: s.status || 'draft',
-          questions: s.questions || [],
-        }));
-        setSurveys(fetchedSurveys);
-      }
+      const surveyResult = await apiFetch(`/surveys?projectId=${projectId}`);
+      const fetchedSurveys = (surveyResult.data || []).map((s: any) => ({
+        ...s,
+        id: s._id,
+        createdAt: s.createdAt || new Date().toISOString(),
+        responseCount: s.responseCount || 0,
+        status: s.status || 'draft',
+        questions: s.questions || [],
+      }));
+      setSurveys(fetchedSurveys);
     } catch (error: any) {
-      if (!apiError) setApiError(error.message || 'Failed to fetch project details from API.');
+      setApiError(error.message || 'Failed to fetch project details from API.');
     } finally {
       setIsLoading(false);
     }
-  };
+  }, [projectId, apiFetch]);
 
   useEffect(() => {
     fetchProjectAndSurveys();
-  }, [projectId]);
+  }, [fetchProjectAndSurveys]);
 
   useEffect(() => {
     const fetchAgentsAndCompanies = async () => {
-      const token = localStorage.getItem('authToken');
-      if (!token) return;
-
       try {
-        const agentsResponse = await fetch('/api/users?role=agent', {
-          headers: { 'Authorization': `Bearer ${token}` },
-        });
-        if (agentsResponse.ok) {
-          const { data } = await agentsResponse.json();
-          setAgents(data || []);
-        }
+        const [agentsData, companiesData, allSurveysData, allProjectsData] = await Promise.all([
+          apiFetch('/users?role=agent'),
+          apiFetch('/companies'),
+          apiFetch('/surveys'),
+          apiFetch('/projects'),
+        ]);
 
-        const companiesResponse = await fetch('/api/companies', {
-          headers: { 'Authorization': `Bearer ${token}` },
-        });
-        if (companiesResponse.ok) {
-          const { data } = await companiesResponse.json();
-          setCompanies(data || []);
-        }
-
-        const allSurveysResponse = await fetch('/api/surveys', {
-          headers: { 'Authorization': `Bearer ${token}` },
-        });
-        if (allSurveysResponse.ok) {
-          const { data } = await allSurveysResponse.json();
-          setAllSurveys(data || []);
-        }
-
-        const allProjectsResponse = await fetch('/api/projects', {
-            headers: { 'Authorization': `Bearer ${token}` },
-        });
-        if (allProjectsResponse.ok) {
-            const { data } = await allProjectsResponse.json();
-            setAllProjects(data || []);
-        }
+        setAgents(agentsData.data || []);
+        setCompanies(companiesData.data || []);
+        setAllSurveys(allSurveysData.data || []);
+        setAllProjects(allProjectsData.data || []);
       } catch (error) {
         console.error("Failed to fetch agents, companies, or all surveys:", error);
       }
     };
 
     fetchAgentsAndCompanies();
-  }, []);
+  }, [apiFetch]);
 
   const handleAddSurvey = useCallback(async (e: React.FormEvent) => {
     e.preventDefault();
     setApiError(null);
-    const token = localStorage.getItem('authToken');
-    if (!token) {
-      setApiError("Authentication required. Please login.");
-      return;
-    }
 
     if (!formData.title.trim()) {
       setApiError("Survey title is required.");
@@ -181,19 +121,10 @@ const ProjectDetails: React.FC = () => {
     }
 
     try {
-      const surveyResponse = await fetch('/api/surveys', {
+      await apiFetch('/surveys', {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${token}`,
-        },
         body: JSON.stringify(formData),
       });
-
-      if (!surveyResponse.ok) {
-        const errorData = await surveyResponse.json().catch(() => ({}));
-        throw new Error(errorData.errors?.[0]?.msg || errorData.error || errorData.msg || `Failed to create survey: ${surveyResponse.statusText}`);
-      }
 
       setIsAddSurveyModalOpen(false);
       resetForm();
@@ -201,30 +132,15 @@ const ProjectDetails: React.FC = () => {
     } catch (error: any) {
       setApiError(error.message || 'An unexpected error occurred while adding the survey.');
     }
-  }, [formData, resetForm]);
+  }, [formData, resetForm, apiFetch]);
 
   const handleUpdateProject = async (updatedProject: Project) => {
     setApiError(null);
-    const token = localStorage.getItem('authToken');
-    if (!token) {
-      setApiError("Authentication required. Please login.");
-      return;
-    }
-
     try {
-      const response = await fetch(`/api/projects/${updatedProject.id}`, {
+      await apiFetch(`/projects/${updatedProject.id}`, {
         method: 'PUT',
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${token}`,
-        },
         body: JSON.stringify(updatedProject),
       });
-
-      if (!response.ok) {
-        const errorData = await response.json().catch(() => ({}));
-        throw new Error(errorData.errors?.[0]?.msg || errorData.error || errorData.msg || `Failed to update project: ${response.statusText}`);
-      }
 
       setIsEditProjectModalOpen(false);
       triggerRefetch();

--- a/src/pages/Projects.tsx
+++ b/src/pages/Projects.tsx
@@ -6,6 +6,7 @@ import { Card, CardContent } from '../components/ui/Card';
 import { Modal } from '../components/ui/Modal';
 import { useAuth } from '../context/AuthContext';
 import { useNavigate } from 'react-router-dom';
+import useApi from '../hooks/useApi';
 
 interface Project {
   id: string;
@@ -25,11 +26,12 @@ const Projects: React.FC = () => {
   });
   const { user } = useAuth();
   const navigate = useNavigate();
+  const apiFetch = useApi();
   const [apiError, setApiError] = useState<string | null>(null);
 
-  const triggerRefetch = () => {
+  const triggerRefetch = useCallback(() => {
     fetchProjects();
-  };
+  }, []);
 
   const resetForm = useCallback(() => {
     setFormData({
@@ -38,58 +40,32 @@ const Projects: React.FC = () => {
     });
   }, []);
 
-  const fetchProjects = async () => {
+  const fetchProjects = useCallback(async () => {
     setIsLoading(true);
     setApiError(null);
-    const token = localStorage.getItem('authToken');
-
-    if (!token) {
-      setApiError("No authentication token found. Please login.");
-      setIsLoading(false);
-      setProjects([]);
-      return;
-    }
-
     try {
-      const response = await fetch('/api/projects', {
-        headers: {
-          'Authorization': `Bearer ${token}`,
-        },
-      });
-
-      if (!response.ok) {
-        const errorData = await response.json().catch(() => ({}));
-        setApiError(errorData.msg || errorData.error || `HTTP error! status: ${response.status}`);
-        setProjects([]);
-      } else {
-        const result = await response.json();
-        const fetchedProjects = (result.data || []).map((p: any) => ({
-          ...p,
-          id: p._id,
-          createdAt: p.createdAt || new Date().toISOString(),
-        }));
-        setProjects(fetchedProjects);
-      }
+      const result = await apiFetch('/projects');
+      const fetchedProjects = (result.data || []).map((p: any) => ({
+        ...p,
+        id: p._id,
+        createdAt: p.createdAt || new Date().toISOString(),
+      }));
+      setProjects(fetchedProjects);
     } catch (error: any) {
-      if (!apiError) setApiError(error.message || 'Failed to fetch projects from API.');
+      setApiError(error.message || 'Failed to fetch projects from API.');
       setProjects([]);
     } finally {
       setIsLoading(false);
     }
-  };
+  }, [apiFetch]);
 
   useEffect(() => {
     fetchProjects();
-  }, [user]);
+  }, [user, fetchProjects]);
 
   const handleAddProject = useCallback(async (e: React.FormEvent) => {
     e.preventDefault();
     setApiError(null);
-    const token = localStorage.getItem('authToken');
-    if (!token) {
-      setApiError("Authentication required. Please login.");
-      return;
-    }
 
     if (!formData.title.trim()) {
       setApiError("Project title is required.");
@@ -97,53 +73,27 @@ const Projects: React.FC = () => {
     }
 
     try {
-      const response = await fetch('/api/projects', {
+      await apiFetch('/projects', {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${token}`,
-        },
         body: JSON.stringify(formData),
       });
-
-      if (!response.ok) {
-        const errorData = await response.json().catch(() => ({}));
-        throw new Error(errorData.errors?.[0]?.msg || errorData.error || errorData.msg || `Failed to create project: ${response.statusText}`);
-      }
-
       setIsAddModalOpen(false);
       resetForm();
       triggerRefetch();
     } catch (error: any) {
       setApiError(error.message || 'An unexpected error occurred while adding the project.');
     }
-  }, [formData, resetForm]);
+  }, [formData, resetForm, triggerRefetch, apiFetch]);
 
   const handleDelete = async (projectId: string) => {
     if (!window.confirm('Are you sure you want to delete this project and all its surveys?')) {
       return;
     }
-
     setApiError(null);
-    const token = localStorage.getItem('authToken');
-    if (!token) {
-      setApiError("Authentication required. Please login.");
-      return;
-    }
-
     try {
-      const response = await fetch(`/api/projects/${projectId}`, {
+      await apiFetch(`/projects/${projectId}`, {
         method: 'DELETE',
-        headers: {
-          'Authorization': `Bearer ${token}`,
-        },
       });
-
-      if (!response.ok) {
-        const errorData = await response.json().catch(() => ({}));
-        throw new Error(errorData.msg || errorData.error || `Failed to delete project: ${response.statusText}`);
-      }
-
       triggerRefetch();
     } catch (error: any) {
       setApiError(error.message || 'An unexpected error occurred while deleting the project.');

--- a/src/pages/Reports.tsx
+++ b/src/pages/Reports.tsx
@@ -7,6 +7,7 @@ import { Card, CardContent } from '../components/ui/Card';
 import { Modal } from '../components/ui/Modal';
 import { useAuth } from '../context/AuthContext';
 import { Report as ReportType, Section } from '../types';
+import useApi from '../hooks/useApi';
 
 const Reports: React.FC = () => {
   const [reports, setReports] = useState<ReportType[]>([]);
@@ -30,6 +31,7 @@ const Reports: React.FC = () => {
   const [isLoadingSurveys, setIsLoadingSurveys] = useState(false);
 
   const { user } = useAuth();
+  const apiFetch = useApi();
   const [apiError, setApiError] = useState<string | null>(null);
 
   useEffect(() => {
@@ -44,20 +46,12 @@ const Reports: React.FC = () => {
 
   const fetchAvailableSurveys = async () => {
     setIsLoadingSurveys(true);
-    const token = localStorage.getItem('authToken');
-    if (!token) {
-      setIsLoadingSurveys(false);
-      return;
-    }
     try {
-      const response = await fetch('/api/surveys', {
-        headers: { 'Authorization': `Bearer ${token}` },
-      });
-      if (!response.ok) throw new Error('Failed to fetch surveys for dropdown.');
-      const data = await response.json();
+      const data = await apiFetch('/surveys');
       setAvailableSurveys((data.data || data || []).map((s: any) => ({ id: s._id || s.id, title: s.title })));
     } catch (error) {
       console.error("Error fetching available surveys:", error);
+      // Optionally set an error state for the modal
     } finally {
       setIsLoadingSurveys(false);
     }
@@ -67,32 +61,7 @@ const Reports: React.FC = () => {
     setIsLoading(true);
     setApiError(null);
     try {
-      const token = localStorage.getItem('authToken');
-      const apiUrl = import.meta.env.VITE_API_URL ? `${import.meta.env.VITE_API_URL}/api/reports` : '/api/reports';
-
-      const headers: HeadersInit = {
-          'Content-Type': 'application/json',
-          'Accept': 'application/json'
-        };
-
-      if (token) {
-        headers['Authorization'] = `Bearer ${token}`;
-      }
-
-      const response = await fetch(apiUrl, { headers });
-
-      if (!response.ok) {
-        let errorMessage = `HTTP error! status: ${response.status}`;
-        try {
-          const errorData = await response.json();
-          errorMessage = errorData.message || errorData.error || errorMessage;
-        } catch (e) {
-          errorMessage = response.statusText || errorMessage;
-        }
-        throw new Error(errorMessage);
-      }
-
-      const data = await response.json();
+      const data = await apiFetch('/reports');
       const fetchedReports = (data.data || data || []).map((r: any) => ({
         ...r,
         id: r._id,
@@ -111,12 +80,6 @@ const Reports: React.FC = () => {
     e.preventDefault();
     setApiError(null);
 
-    const token = localStorage.getItem('authToken');
-    if (!token) {
-      setApiError("Authentication token not found. Please log in again.");
-      return;
-    }
-
     if (!newReport.title || !newReport.description || !newReport.surveyId) {
       setApiError("Title, description, and survey selection are required.");
       return;
@@ -131,26 +94,10 @@ const Reports: React.FC = () => {
     };
 
     try {
-      const apiUrl = import.meta.env.VITE_API_URL ? `${import.meta.env.VITE_API_URL}/api/reports` : '/api/reports';
-      const response = await fetch(apiUrl, {
+      await apiFetch('/reports', {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${token}`,
-        },
         body: JSON.stringify(reportPayload),
       });
-
-      if (!response.ok) {
-        let errorMessage = `HTTP error! status: ${response.status}`;
-        try {
-          const errorData = await response.json();
-          errorMessage = errorData.message || errorData.error || errorMessage;
-        } catch (parseError) {
-          errorMessage = response.statusText || errorMessage;
-        }
-        throw new Error(errorMessage);
-      }
 
       setIsAddModalOpen(false);
       setNewReport({
@@ -186,7 +133,7 @@ const Reports: React.FC = () => {
     setIsDetailModalOpen(true);
   };
 
-  const handleDownloadReport = async (report: ReportType, format: 'pdf' | 'pptx' = 'pdf') => {
+  const handleDownloadReport = async (report: ReportType, format: 'pdf' | 'pptx' | 'xlsx') => {
     const token = localStorage.getItem('authToken');
     if (!token) {
       setApiError('Authentication required to download reports.');

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -4,9 +4,11 @@ import { Card, CardContent, CardHeader, CardTitle } from '../components/ui/Card'
 import { Input } from '../components/ui/Input';
 import { Button } from '../components/ui/Button';
 import { useAuth } from '../context/AuthContext';
+import useApi from '../hooks/useApi';
 
 const Settings: React.FC = () => {
   const { user } = useAuth();
+  const apiFetch = useApi();
   const [formData, setFormData] = useState({
     name: user?.name || '',
     email: user?.email || '',
@@ -42,10 +44,6 @@ const Settings: React.FC = () => {
     console.log('Settings updated:', formData);
 
     if (user?.role === 'admin' && user.companyId) {
-      const token = localStorage.getItem('authToken');
-      if (!token) return;
-
-      const brandingData = new FormData();
       if (branding.logo) {
         // In a real app, you'd upload the logo to a file storage service
         // and get back a URL to save in the database.
@@ -53,19 +51,14 @@ const Settings: React.FC = () => {
         console.log('Logo would be uploaded here.');
       }
 
-      const response = await fetch(`/api/companies/${user.companyId}/branding`, {
-        method: 'PUT',
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${token}`,
-        },
-        body: JSON.stringify({ color: branding.color }),
-      });
-
-      if (response.ok) {
+      try {
+        await apiFetch(`/companies/${user.companyId}/branding`, {
+          method: 'PUT',
+          body: JSON.stringify({ color: branding.color }),
+        });
         console.log('Branding updated successfully');
-      } else {
-        console.error('Failed to update branding');
+      } catch (error) {
+        console.error('Failed to update branding', error);
       }
     }
   };

--- a/src/pages/SurveyList.tsx
+++ b/src/pages/SurveyList.tsx
@@ -7,12 +7,14 @@ import { Modal } from '../components/ui/Modal';
 import { useAuth } from '../context/AuthContext';
 import { Survey, SurveyQuestion } from '../types';
 import SurveyForm from '../components/surveys/SurveyForm';
+import useApi from '../hooks/useApi';
 
 const AllSurveys: React.FC = () => {
   const [surveys, setSurveys] = useState<Survey[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const { user } = useAuth();
   const navigate = useNavigate();
+  const apiFetch = useApi();
   const [apiError, setApiError] = useState<string | null>(null);
   const [isAddSurveyModalOpen, setIsAddSurveyModalOpen] = useState(false);
   const [formData, setFormData] = useState({
@@ -23,49 +25,30 @@ const AllSurveys: React.FC = () => {
   const [agents, setAgents] = useState<any[]>([]);
   const [companies, setCompanies] = useState<any[]>([]);
 
-  const fetchAllSurveys = async () => {
+  const fetchAllSurveys = useCallback(async () => {
     setIsLoading(true);
     setApiError(null);
-    const token = localStorage.getItem('authToken');
-
-    if (!token) {
-      setApiError("No authentication token found. Please login.");
-      setIsLoading(false);
-      return;
-    }
-
     try {
-      const surveyResponse = await fetch(`/api/surveys`, {
-        headers: {
-          'Authorization': `Bearer ${token}`,
-        },
-      });
-
-      if (!surveyResponse.ok) {
-        const errorData = await surveyResponse.json().catch(() => ({}));
-        setApiError(errorData.msg || errorData.error || `HTTP error! status: ${surveyResponse.status}`);
-      } else {
-        const surveyResult = await surveyResponse.json();
-        const fetchedSurveys = (surveyResult.data || []).map((s: any) => ({
-          ...s,
-          id: s._id,
-          createdAt: s.createdAt || new Date().toISOString(),
-          responseCount: s.responseCount || 0,
-          status: s.status || 'draft',
-          questions: s.questions || [],
-        }));
-        setSurveys(fetchedSurveys);
-      }
-    } catch (error) {
-      if (!apiError) setApiError(error.message || 'Failed to fetch surveys from API.');
+      const surveyResult = await apiFetch('/surveys');
+      const fetchedSurveys = (surveyResult.data || []).map((s: any) => ({
+        ...s,
+        id: s._id,
+        createdAt: s.createdAt || new Date().toISOString(),
+        responseCount: s.responseCount || 0,
+        status: s.status || 'draft',
+        questions: s.questions || [],
+      }));
+      setSurveys(fetchedSurveys);
+    } catch (error: any) {
+      setApiError(error.message || 'Failed to fetch surveys from API.');
     } finally {
       setIsLoading(false);
     }
-  };
+  }, [apiFetch]);
 
   useEffect(() => {
     fetchAllSurveys();
-  }, [user]);
+  }, [user, fetchAllSurveys]);
 
   const getStatusColor = (status: string) => {
     switch (status) {
@@ -99,11 +82,6 @@ const AllSurveys: React.FC = () => {
   const handleAddSurvey = useCallback(async (e: React.FormEvent) => {
     e.preventDefault();
     setApiError(null);
-    const token = localStorage.getItem('authToken');
-    if (!token) {
-      setApiError("Authentication required. Please login.");
-      return;
-    }
 
     if (!formData.title.trim()) {
       setApiError("Survey title is required.");
@@ -111,19 +89,10 @@ const AllSurveys: React.FC = () => {
     }
 
     try {
-      const surveyResponse = await fetch('/api/surveys', {
+      await apiFetch('/surveys', {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${token}`,
-        },
         body: JSON.stringify(formData),
       });
-
-      if (!surveyResponse.ok) {
-        const errorData = await surveyResponse.json().catch(() => ({}));
-        throw new Error(errorData.errors?.[0]?.msg || errorData.error || errorData.msg || `Failed to create survey: ${surveyResponse.statusText}`);
-      }
 
       setIsAddSurveyModalOpen(false);
       resetForm();
@@ -131,33 +100,17 @@ const AllSurveys: React.FC = () => {
     } catch (error: any) {
       setApiError(error.message || 'An unexpected error occurred while adding the survey.');
     }
-  }, [formData, resetForm]);
+  }, [formData, resetForm, fetchAllSurveys, apiFetch]);
 
   const handleDelete = async (surveyId: string) => {
     if (!window.confirm('Are you sure you want to delete this survey?')) {
       return;
     }
-
     setApiError(null);
-    const token = localStorage.getItem('authToken');
-    if (!token) {
-      setApiError("Authentication required. Please login.");
-      return;
-    }
-
     try {
-      const response = await fetch(`/api/surveys/${surveyId}`, {
+      await apiFetch(`/surveys/${surveyId}`, {
         method: 'DELETE',
-        headers: {
-          'Authorization': `Bearer ${token}`,
-        },
       });
-
-      if (!response.ok) {
-        const errorData = await response.json().catch(() => ({}));
-        throw new Error(errorData.msg || errorData.error || `Failed to delete survey: ${response.statusText}`);
-      }
-
       fetchAllSurveys();
     } catch (err: any) {
       console.error('Error deleting survey:', err);

--- a/src/pages/SurveyResponsePage.tsx
+++ b/src/pages/SurveyResponsePage.tsx
@@ -5,7 +5,7 @@ import { Survey } from '../types'; // Assuming Survey type might need question s
 import { Button } from '../components/ui/Button';
 import { Input } from '../components/ui/Input'; // For basic text input
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '../components/ui/Card';
-
+import useApi from '../hooks/useApi';
 import { QuestionType } from '../types';
 
 // Define a simple question structure for now
@@ -33,6 +33,7 @@ const SurveyResponsePage: React.FC = () => {
   const { surveyId } = useParams<{ surveyId: string }>();
   const { user } = useAuth();
   const navigate = useNavigate();
+  const apiFetch = useApi();
 
   const [survey, setSurvey] = useState<SurveyWithQuestions | null>(null);
   const [isLoading, setIsLoading] = useState(true);
@@ -51,27 +52,9 @@ const SurveyResponsePage: React.FC = () => {
       }
       setIsLoading(true);
       setError(null);
-      const token = localStorage.getItem('authToken');
-
-      if (!token) {
-        setError("Authentication required. Please login.");
-        setIsLoading(false);
-        return;
-      }
 
       try {
-        const response = await fetch(`/api/surveys/${surveyId}`, {
-          headers: {
-            'Authorization': `Bearer ${token}`,
-          },
-        });
-
-        if (!response.ok) {
-          const errorData = await response.json().catch(() => ({}));
-          throw new Error(errorData.msg || errorData.error || `Failed to fetch survey details: ${response.statusText}`);
-        }
-
-        const surveyData = await response.json();
+        const surveyData = await apiFetch(`/surveys/${surveyId}`);
         const surveyFromApi = surveyData.data || surveyData;
 
         if (!surveyFromApi || !surveyFromApi._id) {
@@ -100,7 +83,7 @@ const SurveyResponsePage: React.FC = () => {
         setIsLoading(false);
     }
     // If token exists but user is null, AuthContext is loading, page will show its own loader.
-  }, [surveyId, user]);
+  }, [surveyId, user, apiFetch]);
 
   const handleFileUpload = async (questionId: string, file: File) => {
     const token = localStorage.getItem('authToken');
@@ -183,30 +166,13 @@ const SurveyResponsePage: React.FC = () => {
     setIsSubmitting(true);
     setError(null);
     setSuccessMessage(null);
-    const token = localStorage.getItem('authToken');
-
-    if (!token) {
-      setError("Authentication required. Please login again.");
-      setIsSubmitting(false);
-      return;
-    }
 
     try {
-      const response = await fetch(`/api/surveys/${surveyId}/responses`, {
+      await apiFetch(`/surveys/${surveyId}/responses`, {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${token}`,
-        },
         body: JSON.stringify({ data: responses }), // Backend expects 'data' field for responseData
       });
 
-      if (!response.ok) {
-        const errorData = await response.json().catch(() => ({}));
-        throw new Error(errorData.msg || errorData.error || `Failed to submit responses: ${response.statusText}`);
-      }
-
-      // const submissionResult = await response.json(); // Contains the created response
       setSuccessMessage("Your response has been submitted successfully!");
       // Optionally, disable the form or redirect:
       // navigate(`/surveys/${surveyId}/thankyou`); or set a state to disable form inputs

--- a/src/pages/Surveys.tsx
+++ b/src/pages/Surveys.tsx
@@ -3,6 +3,7 @@ import { useAuth } from '../context/AuthContext';
 import { useNavigate } from 'react-router-dom';
 import { Survey, SurveyQuestion } from '../types';
 import SurveyForm from '../components/surveys/SurveyForm';
+import useApi from '../hooks/useApi';
 
 const Surveys: React.FC = () => {
   const [formData, setFormData] = useState<{
@@ -20,6 +21,7 @@ const Surveys: React.FC = () => {
   });
   const { user } = useAuth();
   const navigate = useNavigate();
+  const apiFetch = useApi();
   const [apiError, setApiError] = useState<string | null>(null);
   const [agents, setAgents] = useState<{ _id: string; name: string }[]>([]);
   const [companies, setCompanies] = useState<{ _id: string; name: string }[]>([]);
@@ -36,44 +38,26 @@ const Surveys: React.FC = () => {
 
   useEffect(() => {
     const fetchInitialData = async () => {
-      const token = localStorage.getItem('authToken');
-      if (!token) return;
-
       try {
-        const [agentsRes, companiesRes, projectsRes] = await Promise.all([
-          fetch('/api/users?role=agent', { headers: { 'Authorization': `Bearer ${token}` } }),
-          fetch('/api/companies', { headers: { 'Authorization': `Bearer ${token}` } }),
-          fetch('/api/projects', { headers: { 'Authorization': `Bearer ${token}` } })
+        const [agentsData, companiesData, projectsData] = await Promise.all([
+          apiFetch('/users?role=agent'),
+          apiFetch('/companies'),
+          apiFetch('/projects')
         ]);
-
-        if (agentsRes.ok) {
-          const { data } = await agentsRes.json();
-          setAgents(data || []);
-        }
-        if (companiesRes.ok) {
-          const { data } = await companiesRes.json();
-          setCompanies(data || []);
-        }
-        if (projectsRes.ok) {
-          const { data } = await projectsRes.json();
-          setProjects(data || []);
-        }
+        setAgents(agentsData.data || []);
+        setCompanies(companiesData.data || []);
+        setProjects(projectsData.data || []);
       } catch (error) {
         console.error("Failed to fetch initial data:", error);
       }
     };
 
     fetchInitialData();
-  }, []);
+  }, [apiFetch]);
 
   const handleAddSurvey = useCallback(async (e: React.FormEvent) => {
     e.preventDefault();
     setApiError(null);
-    const token = localStorage.getItem('authToken');
-    if (!token) {
-      setApiError("Authentication required. Please login.");
-      return;
-    }
 
     if (!formData.title.trim()) {
       setApiError("Survey title is required.");
@@ -86,26 +70,17 @@ const Surveys: React.FC = () => {
     }
 
     try {
-      const surveyResponse = await fetch('/api/surveys', {
+      await apiFetch('/surveys', {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${token}`,
-        },
         body: JSON.stringify(formData),
       });
-
-      if (!surveyResponse.ok) {
-        const errorData = await surveyResponse.json().catch(() => ({}));
-        throw new Error(errorData.errors?.[0]?.msg || errorData.error || errorData.msg || `Failed to create survey: ${surveyResponse.statusText}`);
-      }
 
       resetForm();
       navigate('/surveys');
     } catch (error: any) {
       setApiError(error.message || 'An unexpected error occurred while adding the survey.');
     }
-  }, [formData, resetForm, navigate]);
+  }, [formData, resetForm, navigate, apiFetch]);
 
   return (
     <div className="p-6">

--- a/src/pages/Users.tsx
+++ b/src/pages/Users.tsx
@@ -6,6 +6,7 @@ import { Card, CardContent } from '../components/ui/Card';
 import { Modal } from '../components/ui/Modal';
 import { useAuth } from '../context/AuthContext';
 import { UserRole } from '../types'; // Assuming UserRole is defined here
+import useApi from '../hooks/useApi';
 
 interface User {
   id: string;
@@ -167,6 +168,7 @@ const Users: React.FC = () => {
     confirmPassword: '',
   });
   const { user: loggedInUser } = useAuth();
+  const apiFetch = useApi();
   const [apiError, setApiError] = useState<string | null>(null);
   const [passwordChangeError, setPasswordChangeError] = useState<string | null>(null); // Specific error for password modal
 
@@ -238,16 +240,7 @@ const Users: React.FC = () => {
 
   const fetchUsers = useCallback(async () => {
     setIsLoading(true);
-    setApiError(null); // Clear previous API errors
-
-    const token = localStorage.getItem('authToken');
-
-    if (!token) {
-      setApiError("Authentication token not found. Please log in.");
-      setIsLoading(false);
-      setUsers([]);
-      return;
-    }
+    setApiError(null);
 
     if (loggedInUser?.role !== UserRole.ADMIN) {
       setApiError("Access Denied: You do not have permission to view users.");
@@ -257,20 +250,7 @@ const Users: React.FC = () => {
     }
 
     try {
-      const response = await fetch('/api/users', {
-        headers: {
-          'Authorization': `Bearer ${token}`,
-        },
-      });
-
-      if (!response.ok) {
-        const errorData = await response.json().catch(() => ({}));
-        const errorMessage = errorData.msg || errorData.error || `Error fetching users: ${response.statusText}`;
-        setApiError(errorMessage);
-        throw new Error(errorMessage);
-      }
-
-      const result = await response.json();
+      const result = await apiFetch('/users');
       const fetchedUsers = (result.data || []).map((u: any) => ({
         ...u,
         id: u._id,
@@ -280,13 +260,12 @@ const Users: React.FC = () => {
       setUsers(fetchedUsers);
     } catch (error: any) {
       console.error('Error fetching users from API:', error);
-      // apiError is already set by the response.ok check, only set if no specific error
-      if (!apiError) setApiError(error.message || 'Failed to fetch users. Please try again.');
+      setApiError(error.message || 'Failed to fetch users. Please try again.');
       setUsers([]);
     } finally {
       setIsLoading(false);
     }
-}, [loggedInUser]); // Removed apiError dependency to prevent loops
+  }, [loggedInUser, apiFetch]);
 
 // This useEffect handles initial data fetch and re-fetch on user change
 useEffect(() => {
@@ -309,32 +288,16 @@ useEffect(() => {
 
 const fetchCompanies = useCallback(async () => {
   setIsLoadingCompanies(true);
-  const token = localStorage.getItem('authToken');
-  // Assuming all authenticated users can fetch companies for the dropdown
-  if (!token) {
-    // Not setting apiError here as it's for the main user list,
-    // but logging for debug. The dropdown will just be empty or show loading.
-    console.error("No auth token for fetching companies.");
-    setIsLoadingCompanies(false);
-    return;
-  }
   try {
-    const response = await fetch('/api/companies', { // Assuming this is the endpoint
-      headers: { 'Authorization': `Bearer ${token}` },
-    });
-    if (!response.ok) {
-      throw new Error('Failed to fetch companies');
-    }
-    const result = await response.json();
-    // Assuming result.data is an array of { _id: string, name: string, ... }
+    const result = await apiFetch('/companies');
     setCompanies((result.data || []).map((c: any) => ({ id: c._id || c.id, name: c.name })));
   } catch (error) {
     console.error("Error fetching companies:", error);
-    setCompanies([]); // Clear on error
+    setCompanies([]);
   } finally {
     setIsLoadingCompanies(false);
   }
-}, []); // No dependencies, fetches once or on demand
+}, [apiFetch]);
 
 // Fetch companies when component mounts (or when modals are about to open - later optimization)
 useEffect(() => {
@@ -344,12 +307,7 @@ useEffect(() => {
   const handleAddUser = useCallback(async (e: React.FormEvent) => {
     e.preventDefault();
     setApiError(null);
-    const token = localStorage.getItem('authToken');
 
-    if (!token) {
-      setApiError("Authentication required.");
-      return;
-    }
     if (formData.password !== formData.confirmPassword) {
       setApiError("Passwords do not match.");
       return;
@@ -364,12 +322,8 @@ useEffect(() => {
     }
 
     try {
-      const response = await fetch('/api/auth/register', {
+      await apiFetch('/auth/register', {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${token}`,
-        },
         body: JSON.stringify({
           name: formData.name,
           email: formData.email,
@@ -379,19 +333,14 @@ useEffect(() => {
         }),
       });
 
-      if (!response.ok) {
-        const errorData = await response.json().catch(() => ({}));
-        throw new Error(errorData.errors?.[0]?.msg || errorData.error || errorData.msg || `Failed to add user: ${response.statusText}`);
-      }
-
-      await fetchUsers(); // Re-fetch the user list to include the new user
+      await fetchUsers();
       setIsAddModalOpen(false);
       resetForm();
     } catch (error: any) {
       console.error('Error adding user via API:', error);
       setApiError(error.message || 'An unexpected error occurred while adding the user.');
     }
-  }, [formData, resetForm, fetchUsers]);
+  }, [formData, resetForm, fetchUsers, apiFetch]);
 
   const handleEditUser = useCallback(async (e: React.FormEvent) => {
     e.preventDefault();
@@ -400,11 +349,6 @@ useEffect(() => {
       return;
     }
     setApiError(null);
-    const token = localStorage.getItem('authToken');
-    if (!token) {
-      setApiError("Authentication required.");
-      return;
-    }
 
     if (formData.role === UserRole.CLIENT && !formData.companyId) {
         setApiError("Company ID is required for Client role.");
@@ -416,25 +360,14 @@ useEffect(() => {
       role: formData.role,
       status: editingUser.status, // Preserve existing status
     };
-    // Send companyId as null if empty string to explicitly unset it on backend
     payload.companyId = formData.companyId === '' ? null : formData.companyId;
 
     try {
-      const response = await fetch(`/api/users/${editingUser.id}`, {
+      const updatedUserFromApi = await apiFetch(`/users/${editingUser.id}`, {
         method: 'PUT',
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${token}`,
-        },
         body: JSON.stringify(payload),
       });
 
-      if (!response.ok) {
-        const errorData = await response.json().catch(() => ({}));
-        throw new Error(errorData.errors?.[0]?.msg || errorData.error || errorData.msg || `Failed to update user: ${response.statusText}`);
-      }
-
-      const updatedUserFromApi = await response.json();
       const updatedUser = {
         ...(updatedUserFromApi.data || updatedUserFromApi),
         id: (updatedUserFromApi.data || updatedUserFromApi)._id,
@@ -449,16 +382,10 @@ useEffect(() => {
       console.error('Error updating user via API:', error);
       setApiError(error.message || 'An unexpected error occurred while updating the user.');
     }
-  }, [formData, editingUser, resetForm]);
+  }, [formData, editingUser, resetForm, apiFetch]);
 
   const handleToggleUserStatus = useCallback(async (userId: string, currentStatus: 'active' | 'inactive') => {
     setApiError(null);
-    const token = localStorage.getItem('authToken');
-    if (!token) {
-      setApiError("Authentication required.");
-      return;
-    }
-
     const newStatus = currentStatus === 'active' ? 'inactive' : 'active';
     const originalUsers = [...users];
 
@@ -469,22 +396,11 @@ useEffect(() => {
     );
 
     try {
-      const response = await fetch(`/api/users/${userId}`, {
+      const updatedUserFromApi = await apiFetch(`/users/${userId}`, {
         method: 'PUT',
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${token}`,
-        },
         body: JSON.stringify({ status: newStatus }),
       });
 
-      if (!response.ok) {
-        const errorData = await response.json().catch(() => ({}));
-        setUsers(originalUsers); // Revert optimistic update
-        throw new Error(errorData.errors?.[0]?.msg || errorData.error || errorData.msg || `Failed to update user status: ${response.statusText}`);
-      }
-
-      const updatedUserFromApi = await response.json();
       const finalUpdatedUser = {
         ...(updatedUserFromApi.data || updatedUserFromApi),
         id: (updatedUserFromApi.data || updatedUserFromApi)._id,
@@ -492,13 +408,12 @@ useEffect(() => {
       setUsers(prevUsers =>
         prevUsers.map(u => (u.id === finalUpdatedUser.id ? { ...u, ...finalUpdatedUser, avatar: u.avatar } : u))
       );
-
     } catch (error: any) {
       console.error('Error updating user status via API:', error);
       setApiError(error.message || 'An unexpected error occurred while updating user status.');
-      setUsers(originalUsers); // Ensure reversion on any catch
+      setUsers(originalUsers);
     }
-  }, [users]);
+  }, [users, apiFetch]);
 
   const startEdit = useCallback((user: User) => {
     setEditingUser(user);
@@ -538,26 +453,11 @@ useEffect(() => {
       return;
     }
 
-    const token = localStorage.getItem('authToken');
-    if (!token) {
-      setPasswordChangeError("Authentication error. Please log in again.");
-      return;
-    }
-
     try {
-      const response = await fetch(`/api/users/${changePasswordUserId}/set-password`, {
+      await apiFetch(`/users/${changePasswordUserId}/set-password`, {
         method: 'PUT',
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${token}`,
-        },
         body: JSON.stringify({ newPassword }),
       });
-
-      if (!response.ok) {
-        const errorData = await response.json().catch(() => ({}));
-        throw new Error(errorData.errors?.[0]?.msg || errorData.msg || errorData.error || `Failed to change password: ${response.statusText}`);
-      }
 
       alert('Password updated successfully!');
       handleCancelChangePassword();
@@ -566,7 +466,7 @@ useEffect(() => {
       console.error('Error changing password:', error);
       setPasswordChangeError(error.message || 'Could not update password.');
     }
-  }, [newPassword, confirmNewPassword, changePasswordUserId, handleCancelChangePassword]);
+  }, [newPassword, confirmNewPassword, changePasswordUserId, handleCancelChangePassword, apiFetch]);
 
   // --- Effects ---
   useEffect(() => {


### PR DESCRIPTION
The application was experiencing widespread 401 Unauthorized errors due to direct `fetch()` calls being made without proper authentication headers or token refresh logic.

This change refactors all identified instances of direct API calls across the frontend to use the centralized `useApi` hook. This ensures that all standard API requests are properly authenticated with a Bearer token and will gracefully handle token expiration by attempting to refresh the token.

The refactoring covered the following areas:
- Reports
- Surveys
- Projects
- Companies
- Users
- Settings

Special cases like the login flow, file downloads, and file uploads still use `fetch` directly, as the `useApi` hook is specialized for JSON API responses, but these instances were verified to handle authentication correctly.