### PR TITLE
fix: Disable dummy data in reports controller

### DIFF
--- a/server/controllers/reports.js
+++ b/server/controllers/reports.js
@@ -95,7 +95,7 @@ export const generateReport = async (req, res) => {
 // @route   GET /api/reports
 // @access  Private (Admins, Agents, Clients)
 export const getReports = async (req, res) => {
-  const useDummyData = true; // Set to true to use dummy data
+  const useDummyData = false; // Set to true to use dummy data
 
   if (useDummyData) {
     const dummyReports = [


### PR DESCRIPTION
The `getReports` function in the reports controller was using hardcoded dummy data, which prevented newly submitted surveys from being displayed. This commit disables the dummy data, allowing the frontend to fetch real report data from the database.