### PR TITLE
feat: Implement Multi-Survey Analysis module

### DIFF
--- a/server/controllers/multi-survey-analysis.js
+++ b/server/controllers/multi-survey-analysis.js
@@ -1,6 +1,60 @@
+import { getDb } from '../utils/db.js';
+import { ObjectId } from 'mongodb';
+
 export const getMultiSurveyAnalysisData = async (req, res, next) => {
   try {
-    res.json({ status: 'success', data: { message: 'Multi-survey analysis data will be here.' } });
+    const db = getDb();
+    const { survey_group_id } = req.query;
+
+    if (!survey_group_id || !ObjectId.isValid(survey_group_id)) {
+      return res.status(400).json({ message: 'A valid survey_group_id is required.' });
+    }
+
+    const surveyGroup = await db.collection('survey_groups').findOne({ _id: new ObjectId(survey_group_id) });
+
+    if (!surveyGroup) {
+      return res.status(404).json({ message: 'Survey group not found.' });
+    }
+
+    const surveyIds = surveyGroup.surveyIds.map(id => new ObjectId(id));
+
+    // Fetch all surveys in the group to get their questions
+    const surveys = await db.collection('surveys').find({ _id: { $in: surveyIds } }).toArray();
+
+    // Fetch all responses for the surveys in the group
+    const responses = await db.collection('responses').find({ surveyId: { $in: surveyIds } }).toArray();
+
+    const aggregatedData = {};
+
+    // Initialize aggregatedData with all questions from all surveys
+    surveys.forEach(survey => {
+      survey.questions.forEach(question => {
+        if (!aggregatedData[question.id]) {
+          aggregatedData[question.id] = {
+            text: question.text,
+            type: question.type,
+            responses: {}
+          };
+        }
+      });
+    });
+
+    // Aggregate responses
+    responses.forEach(response => {
+      for (const [questionId, answer] of Object.entries(response.responseData)) {
+        if (aggregatedData[questionId]) {
+          if (Array.isArray(answer)) { // For multiple-choice
+            answer.forEach(option => {
+              aggregatedData[questionId].responses[option] = (aggregatedData[questionId].responses[option] || 0) + 1;
+            });
+          } else { // For single-choice, rating, etc.
+            aggregatedData[questionId].responses[answer] = (aggregatedData[questionId].responses[answer] || 0) + 1;
+          }
+        }
+      }
+    });
+
+    res.json({ status: 'success', data: aggregatedData });
   } catch (error) {
     next(error);
   }

--- a/server/index.js
+++ b/server/index.js
@@ -29,6 +29,7 @@ import advancedAnalyticsRoutes from './routes/advanced-analytics.js';
 import collaborationRoutes from './routes/collaboration.js';
 import reminderRoutes from './routes/reminders.js';
 import multiSurveyAnalysisRoutes from './routes/multi-survey-analysis.js';
+import surveyGroupsRoutes from './routes/surveyGroups.js';
 import dashboardRoutes from './routes/dashboard.js';
 import scheduleReportGeneration from './services/reportingService.js';
 import { scheduleReminderJobs } from './services/reminderService.js';
@@ -93,6 +94,7 @@ app.use('/api/advanced-analytics', advancedAnalyticsRoutes);
 app.use('/api/collaboration', collaborationRoutes);
 app.use('/api/reminders', reminderRoutes);
 app.use('/api/multi-survey-analysis', multiSurveyAnalysisRoutes);
+app.use('/api/survey-groups', surveyGroupsRoutes);
 
 import statsRoutes from './routes/stats.js';
 app.use('/api/stats', statsRoutes);

--- a/server/routes/surveyGroups.js
+++ b/server/routes/surveyGroups.js
@@ -27,6 +27,18 @@ router.post('/', verifyToken, authorizeRole(['admin', 'agent']), async (req, res
   }
 });
 
+// Get all survey groups
+router.get('/', verifyToken, authorizeRole(['admin', 'agent']), async (req, res) => {
+  try {
+    const db = getDb();
+    const groups = await db.collection('survey_groups').find({}).toArray();
+    res.json(groups);
+  } catch (err) {
+    console.error('Failed to get survey groups:', err);
+    res.status(500).json({ error: 'Failed to get survey groups' });
+  }
+});
+
 // Get a survey group
 router.get('/:id', verifyToken, authorizeRole(['admin', 'agent']), async (req, res) => {
   try {

--- a/src/components/surveys/SurveyGroupManager.tsx
+++ b/src/components/surveys/SurveyGroupManager.tsx
@@ -1,0 +1,133 @@
+import React, { useState, useEffect } from 'react';
+import useApi from '../../hooks/useApi';
+
+interface Survey {
+  _id: string;
+  title: string;
+}
+
+interface SurveyGroup {
+  _id: string;
+  name: string;
+}
+
+const SurveyGroupManager: React.FC = () => {
+  const [surveys, setSurveys] = useState<Survey[]>([]);
+  const [surveyGroups, setSurveyGroups] = useState<SurveyGroup[]>([]);
+  const [newGroupName, setNewGroupName] = useState('');
+  const [selectedSurvey, setSelectedSurvey] = useState('');
+  const [selectedGroup, setSelectedGroup] = useState('');
+  const api = useApi();
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const [surveysData, groupsData] = await Promise.all([
+          api('/surveys'),
+          api('/survey-groups')
+        ]);
+        setSurveys(surveysData.data);
+        setSurveyGroups(groupsData);
+      } catch (error) {
+        console.error('Failed to fetch data:', error);
+      }
+    };
+    fetchData();
+  }, [api]);
+
+  const handleCreateGroup = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!newGroupName) return;
+    try {
+      const newGroup = await api('/survey-groups', {
+        method: 'POST',
+        body: JSON.stringify({ name: newGroupName, surveyIds: [] }),
+      });
+      setSurveyGroups([...surveyGroups, newGroup]);
+      setNewGroupName('');
+    } catch (error) {
+      console.error('Failed to create survey group:', error);
+    }
+  };
+
+  const handleAddSurveyToGroup = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!selectedSurvey || !selectedGroup) return;
+    try {
+      // This is not ideal, we should have a dedicated endpoint for this
+      // For now, we fetch the group, add the survey, and then PUT it back
+      const group = surveyGroups.find(g => g._id === selectedGroup);
+      if (group) {
+        // @ts-ignore
+        const surveyIds = group.surveyIds || [];
+        // @ts-ignore
+        if (!surveyIds.includes(selectedSurvey)) {
+          // @ts-ignore
+          surveyIds.push(selectedSurvey);
+        }
+        await api(`/survey-groups/${selectedGroup}`, {
+          method: 'PUT',
+          body: JSON.stringify({ name: group.name, surveyIds }),
+        });
+        alert('Survey added to group!');
+      }
+    } catch (error) {
+      console.error('Failed to add survey to group:', error);
+    }
+  };
+
+  return (
+    <div className="space-y-8">
+      <div>
+        <h2 className="text-2xl font-bold mb-2">Create Survey Group</h2>
+        <form onSubmit={handleCreateGroup}>
+          <input
+            type="text"
+            value={newGroupName}
+            onChange={(e) => setNewGroupName(e.target.value)}
+            placeholder="New group name"
+            className="p-2 border rounded"
+          />
+          <button type="submit" className="ml-2 px-4 py-2 bg-blue-500 text-white rounded">
+            Create Group
+          </button>
+        </form>
+      </div>
+
+      <div>
+        <h2 className="text-2xl font-bold mb-2">Add Survey to Group</h2>
+        <form onSubmit={handleAddSurveyToGroup}>
+          <select
+            value={selectedSurvey}
+            onChange={(e) => setSelectedSurvey(e.target.value)}
+            className="p-2 border rounded"
+          >
+            <option value="">Select a Survey</option>
+            {surveys.map((survey) => (
+              <option key={survey._id} value={survey._id}>
+                {survey.title}
+              </option>
+            ))}
+          </select>
+          <select
+            value={selectedGroup}
+            onChange={(e) => setSelectedGroup(e.target.value)}
+            className="ml-2 p-2 border rounded"
+          >
+            <option value="">Select a Group</option>
+            {surveyGroups.map((group) => (
+              <option key={group._id} value={group._id}>
+                {group.name}
+              </option>
+            ))}
+          </select>
+          <button type="submit" className="ml-2 px-4 py-2 bg-blue-500 text-white rounded">
+            Add to Group
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default SurveyGroupManager;

--- a/src/pages/MultiSurveyAnalysis.tsx
+++ b/src/pages/MultiSurveyAnalysis.tsx
@@ -1,10 +1,111 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
+import useApi from '../hooks/useApi';
+import SurveyGroupManager from '../components/surveys/SurveyGroupManager';
+
+interface SurveyGroup {
+  _id: string;
+  name: string;
+}
+
+interface AggregatedData {
+  [questionId: string]: {
+    text: string;
+    type: string;
+    responses: {
+      [answer: string]: number;
+    };
+  };
+}
 
 const MultiSurveyAnalysis: React.FC = () => {
+  const [surveyGroups, setSurveyGroups] = useState<SurveyGroup[]>([]);
+  const [selectedGroup, setSelectedGroup] = useState<string>('');
+  const [analysisData, setAnalysisData] = useState<AggregatedData | null>(null);
+  const [loading, setLoading] = useState<boolean>(false);
+  const api = useApi();
+
+  useEffect(() => {
+    const fetchSurveyGroups = async () => {
+      try {
+        const data = await api('/survey-groups');
+        setSurveyGroups(data);
+      } catch (error) {
+        console.error('Failed to fetch survey groups:', error);
+      }
+    };
+    fetchSurveyGroups();
+  }, [api]);
+
+  const handleFetchAnalysis = async () => {
+    if (!selectedGroup) return;
+    setLoading(true);
+    try {
+      const data = await api(`/multi-survey-analysis?survey_group_id=${selectedGroup}`);
+      setAnalysisData(data.data);
+    } catch (error) {
+      console.error('Failed to fetch analysis data:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
   return (
-    <div>
-      <h1 className="text-3xl font-bold">Multi-Survey Analysis</h1>
-      <p>This is where the multi-survey analysis will be displayed.</p>
+    <div className="space-y-8">
+      <div>
+        <h1 className="text-3xl font-bold mb-4">Multi-Survey Analysis</h1>
+        <div className="flex items-center mb-4">
+          <select
+            value={selectedGroup}
+          onChange={(e) => setSelectedGroup(e.target.value)}
+          className="p-2 border rounded"
+        >
+          <option value="">Select a Survey Group</option>
+          {surveyGroups.map((group) => (
+            <option key={group._id} value={group._id}>
+              {group.name}
+            </option>
+          ))}
+        </select>
+        <button
+          onClick={handleFetchAnalysis}
+          disabled={!selectedGroup || loading}
+          className="ml-2 px-4 py-2 bg-blue-500 text-white rounded disabled:bg-gray-400"
+        >
+          {loading ? 'Loading...' : 'Analyze'}
+        </button>
+      </div>
+
+      {analysisData && (
+        <div>
+          <h2 className="text-2xl font-bold mb-2">Analysis Results</h2>
+          <div className="space-y-4">
+            {Object.entries(analysisData).map(([questionId, data]) => (
+              <div key={questionId} className="p-4 border rounded">
+                <h3 className="font-bold">{data.text}</h3>
+                <p className="text-sm text-gray-500">Type: {data.type}</p>
+                <table className="w-full mt-2 text-left">
+                  <thead>
+                    <tr>
+                      <th className="p-2 border-b">Answer</th>
+                      <th className="p-2 border-b">Count</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {Object.entries(data.responses).map(([answer, count]) => (
+                      <tr key={answer}>
+                        <td className="p-2 border-b">{answer}</td>
+                        <td className="p-2 border-b">{count}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+      <hr />
+      <SurveyGroupManager />
     </div>
   );
 };


### PR DESCRIPTION
This commit introduces the Multi-Survey Analysis module, allowing users to group surveys and analyze their responses in aggregate.

**Backend:**
- Implemented a new API endpoint `/api/multi-survey-analysis` to perform the analysis.
- The controller logic fetches all surveys within a specified group, gathers all their responses, and aggregates the results by question.
- Enhanced the existing `/api/survey-groups` routes to support fetching all groups.
- Corrected the test environment by adding the missing `@babel/preset-env` dependency.

**Frontend:**
- Created a new page at `/multi-survey-analysis` to display the analysis UI.
- The page allows users to select a survey group and view the aggregated response data in a table format.
- Added a `SurveyGroupManager` component to the page, enabling users to create new survey groups and add existing surveys to them.