### PR TITLE
fix(frontend): Correct unclosed div in MultiSurveyAnalysis component

### DIFF
--- a/src/pages/MultiSurveyAnalysis.tsx
+++ b/src/pages/MultiSurveyAnalysis.tsx
@@ -74,6 +74,7 @@ const MultiSurveyAnalysis: React.FC = () => {
           {loading ? 'Loading...' : 'Analyze'}
         </button>
       </div>
+      </div>
 
       {analysisData && (
         <div>


### PR DESCRIPTION
This commit fixes a build error in the MultiSurveyAnalysis component caused by a missing closing `</div>` tag. The error was preventing the application from building successfully.