### PR TITLE
feat: Remove admin-only restriction for users and companies pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -112,7 +112,7 @@ const AppRoutes: React.FC = () => {
         } />
         <Route path="/users" element={
           <ProtectedRoute>
-            {user?.role === 'admin' ? <Users /> : <Navigate to="/" />}
+            <Users />
           </ProtectedRoute>
         } />
         <Route path="/settings" element={
@@ -122,7 +122,7 @@ const AppRoutes: React.FC = () => {
         } />
         <Route path="/companies" element={
           <ProtectedRoute>
-            {user?.role === 'admin' ? <Companies /> : <Navigate to="/" />}
+            <Companies />
           </ProtectedRoute>
         } />
         <Route path="/surveys/:surveyId/respond" element={

--- a/src/pages/Users.tsx
+++ b/src/pages/Users.tsx
@@ -255,13 +255,6 @@ const Users: React.FC = () => {
     setIsLoading(true);
     setApiError(null);
 
-    if (loggedInUser?.role !== UserRole.ADMIN) {
-      setApiError("Access Denied: You do not have permission to view users.");
-      setIsLoading(false);
-      setUsers([]);
-      return;
-    }
-
     try {
       const result = await apiFetch('/users');
       const fetchedUsers = (result.data || []).map((u: any) => ({
@@ -282,14 +275,9 @@ const Users: React.FC = () => {
 
 // This useEffect handles initial data fetch and re-fetch on user change
 useEffect(() => {
-  if (loggedInUser && loggedInUser.role === UserRole.ADMIN) {
+  if (loggedInUser) {
     fetchUsers();
-  } else if (loggedInUser && loggedInUser.role !== UserRole.ADMIN) { 
-    // If logged in but not admin
-    setApiError("Access Denied: You do not have permission to view users.");
-    setIsLoading(false);
-    setUsers([]);
-  } else if (!loggedInUser && !localStorage.getItem('authToken')) { 
+  } else if (!localStorage.getItem('authToken')) {
     // Explicitly not logged in (no token)
     setApiError("No authentication token found. Please login.");
     setIsLoading(false);


### PR DESCRIPTION
This commit removes the admin-only restriction for accessing the Users and Companies pages.

- Updated the frontend routing in `src/App.tsx` to allow any authenticated user to access the `/users` and `/companies` routes.
- Updated the `Users` page component in `src/pages/Users.tsx` to remove the internal admin-only check.