### PR TITLE
feat: Make Users and Companies links visible to all users

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -28,12 +28,8 @@ const Header: React.FC = () => {
             <NavLink to="/reports">Reports</NavLink>
             <NavLink to="/collaboration">Collaboration</NavLink>
             <NavLink to="/multi-survey-dashboard">Multi-Survey Analysis</NavLink>
-            {user?.role === 'admin' && (
-              <>
-                <NavLink to="/users">Users</NavLink>
-                <NavLink to="/companies">Companies</NavLink>
-              </>
-            )}
+            <NavLink to="/users">Users</NavLink>
+            <NavLink to="/companies">Companies</NavLink>
             <NavLink to="/settings">Settings</NavLink>
           </nav>
         </div>


### PR DESCRIPTION
This commit removes the admin-only visibility restriction from the "Users" and "Companies" links in the top navigation bar. Now, all authenticated users can see these links.