### PR TITLE
feat: Make users and companies modules accessible in nav

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -27,12 +27,8 @@ const Header: React.FC = () => {
             <NavLink to="/reports">Reports</NavLink>
             <NavLink to="/multi-survey-dashboard">Multi-Survey Analysis</NavLink>
             <NavLink to="/market-research">Market Research</NavLink>
-            {user?.role === 'admin' && (
-              <>
-                <NavLink to="/users">Users</NavLink>
-                <NavLink to="/companies">Companies</NavLink>
-              </>
-            )}
+            <NavLink to="/users">Users</NavLink>
+            <NavLink to="/companies">Companies</NavLink>
             <NavLink to="/settings">Settings</NavLink>
           </nav>
         </div>

--- a/src/pages/Companies.tsx
+++ b/src/pages/Companies.tsx
@@ -426,20 +426,24 @@ const Companies: React.FC = () => {
                     Added {formatDate(company.createdAt)}
                   </span>
                   <div className="space-x-2">
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      onClick={() => startEdit(company)}
-                    >
-                      Edit
-                    </Button>
-                    <Button
-                      variant="danger"
-                      size="sm"
-                      onClick={() => openDeleteModal(company)}
-                    >
-                      Delete
-                    </Button>
+                    {loggedInUser?.role === 'admin' && (
+                      <>
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={() => startEdit(company)}
+                        >
+                          Edit
+                        </Button>
+                        <Button
+                          variant="danger"
+                          size="sm"
+                          onClick={() => openDeleteModal(company)}
+                        >
+                          Delete
+                        </Button>
+                      </>
+                    )}
                   </div>
                 </div>
               </div>

--- a/src/pages/Users.tsx
+++ b/src/pages/Users.tsx
@@ -487,13 +487,9 @@ useEffect(() => {
 
   // --- Effects ---
   useEffect(() => {
-    if (loggedInUser && loggedInUser.role === UserRole.ADMIN) {
+    if (loggedInUser) {
       fetchUsers();
-    } else if (loggedInUser && loggedInUser.role !== UserRole.ADMIN) {
-      setApiError("Access Denied: You do not have permission to view users.");
-      setIsLoading(false);
-      setUsers([]);
-    } else if (!loggedInUser && !localStorage.getItem('authToken')) {
+    } else if (!localStorage.getItem('authToken')) {
       setApiError("No authentication token found. Please log in.");
       setIsLoading(false);
       setUsers([]);
@@ -599,28 +595,30 @@ useEffect(() => {
               </div>
 
               <div className="flex items-center justify-end mt-4 pt-4 border-t border-gray-100 space-x-2">
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() => startEdit(user)}
-                >
-                  Edit
-                </Button>
-                <Button
-                  variant="danger"
-                  size="sm"
-                  onClick={() => openDeleteModal(user)}
-                >
-                  Delete
-                </Button>
-                {loggedInUser?.role === UserRole.ADMIN && ( // Only admins can change passwords for others
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={() => openChangePasswordModal(user.id)}
-                  >
-                    Change Password
-                  </Button>
+                {loggedInUser?.role === UserRole.ADMIN && (
+                  <>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => startEdit(user)}
+                    >
+                      Edit
+                    </Button>
+                    <Button
+                      variant="danger"
+                      size="sm"
+                      onClick={() => openDeleteModal(user)}
+                    >
+                      Delete
+                    </Button>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => openChangePasswordModal(user.id)}
+                    >
+                      Change Password
+                    </Button>
+                  </>
                 )}
               </div>
             </CardContent>


### PR DESCRIPTION
Makes the users and companies modules accessible from the top navigation bar for all authenticated users.

Previously, these modules were only visible to admin users. This change removes the admin-only restriction for viewing the pages, while keeping the management actions (add, edit, delete) restricted to admins.