### PR TITLE
fix: Allow non-admin users to view users list

### DIFF
--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -12,11 +12,10 @@ import {
 
 const router = express.Router();
 
-// GET all users (Admin only)
+// GET all users
 router.get(
     '/',
     verifyToken,
-    authorizeRole(['admin']),
     getUsers
 );
 


### PR DESCRIPTION
Removes the admin-only authorization from the `GET /users` backend route. This was preventing non-admin users from fetching the list of users and causing the users page to appear blank.

This change makes the behavior of the users route consistent with the companies route, which already allowed access for all authenticated users.