### PR TITLE
fix(frontend): Resolve temporal deadzone error in SurveyForm

### DIFF
--- a/src/components/surveys/SurveyForm.tsx
+++ b/src/components/surveys/SurveyForm.tsx
@@ -7,7 +7,7 @@ const ItemTypes = {
   QUESTION: 'question',
 };
 
-const DraggableQuestion = ({ id, index, moveQuestion, children }) => {
+function DraggableQuestion({ id, index, moveQuestion, children }) {
   const ref = React.useRef(null);
   const [, drop] = useDrop({
     accept: ItemTypes.QUESTION,
@@ -50,7 +50,7 @@ const DraggableQuestion = ({ id, index, moveQuestion, children }) => {
       {children}
     </div>
   );
-};
+}
 
 
 const SurveyForm = ({ formData, onFormDataChange, onSubmit, onCancel, buttonText, agents, companies, projects, user, onDrop }) => {


### PR DESCRIPTION
Changed the `DraggableQuestion` component within `SurveyForm.tsx` from a `const` arrow function to a function declaration.

This change addresses a "ReferenceError: Cannot access 'j' before initialization" that occurred in the production build. While the root cause is likely a subtle circular dependency or module loading issue during Vite's bundling process, converting the component to a hoisted function declaration ensures it is initialized before being referenced, thus avoiding the temporal dead zone (TDZ) error.