### PR TITLE
fix: Make multigrade question not compulsory

### DIFF
--- a/src/pages/SurveyResponsePage.tsx
+++ b/src/pages/SurveyResponsePage.tsx
@@ -146,7 +146,13 @@ const SurveyResponsePage: React.FC = () => {
   const handleSubmitResponse = async (e: React.FormEvent) => {
     e.preventDefault();
 
-    const requiredQuestionsOnPage = visibleQuestions.filter(q => q.isRequired);
+    const requiredQuestionsOnPage = visibleQuestions.filter(q => {
+      // Specific override to make a question non-compulsory
+      if (q.text.includes('Reason(s) for operating the classes as Multigrade')) {
+        return false;
+      }
+      return q.isRequired;
+    });
     const unansweredRequiredQuestions = requiredQuestionsOnPage.filter(q => !responses[q.id]);
 
     if (unansweredRequiredQuestions.length > 0) {


### PR DESCRIPTION
This change modifies the survey response page to override the 'required' validation for a specific question about multigrade classes, making it non-compulsory as requested.