### PR TITLE
feat: Update survey form to improve company and project association

### DIFF
--- a/src/components/surveys/SurveyForm.tsx
+++ b/src/components/surveys/SurveyForm.tsx
@@ -223,37 +223,35 @@ const SurveyForm = ({ formData, onFormDataChange, onSubmit, onCancel, buttonText
         </div>
 
         {user?.role === 'admin' && (
-          <>
-            <div className="mb-4">
-              <label htmlFor="agent" className="block text-sm font-medium text-gray-700">Agent</label>
-              <select
-                id="agent"
-                value={formData.agentId}
-                onChange={(e) => onFormDataChange({ ...formData, agentId: e.target.value })}
-                className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 sm:text-sm"
-              >
-                <option value="">Select an agent</option>
-                {agents.map(agent => (
-                  <option key={agent._id} value={agent._id}>{agent.name}</option>
-                ))}
-              </select>
-            </div>
-            <div className="mb-4">
-              <label htmlFor="companies" className="block text-sm font-medium text-gray-700">Companies</label>
-              <select
-                id="companies"
-                multiple
-                value={formData.companyIds}
-                onChange={(e) => onFormDataChange({ ...formData, companyIds: Array.from(e.target.selectedOptions, option => option.value) })}
-                className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 sm:text-sm"
-              >
-                {companies.map(company => (
-                  <option key={company._id} value={company._id}>{company.name}</option>
-                ))}
-              </select>
-            </div>
-          </>
+          <div className="mb-4">
+            <label htmlFor="agent" className="block text-sm font-medium text-gray-700">Agent</label>
+            <select
+              id="agent"
+              value={formData.agentId}
+              onChange={(e) => onFormDataChange({ ...formData, agentId: e.target.value })}
+              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 sm:text-sm"
+            >
+              <option value="">Select an agent</option>
+              {agents.map(agent => (
+                <option key={agent._id} value={agent._id}>{agent.name}</option>
+              ))}
+            </select>
+          </div>
         )}
+        <div className="mb-4">
+          <label htmlFor="companies" className="block text-sm font-medium text-gray-700">Companies</label>
+          <select
+            id="companies"
+            multiple
+            value={formData.companyIds}
+            onChange={(e) => onFormDataChange({ ...formData, companyIds: Array.from(e.target.selectedOptions, option => option.value) })}
+            className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 sm:text-sm"
+          >
+            {companies.map(company => (
+              <option key={company._id} value={company._id}>{company.name}</option>
+            ))}
+          </select>
+        </div>
 
         <div className="mb-4">
           <h3 className="text-lg font-medium text-gray-900">Questions</h3>

--- a/src/pages/Surveys.tsx
+++ b/src/pages/Surveys.tsx
@@ -18,6 +18,7 @@ const Surveys: React.FC = () => {
     description: '',
     questions: [],
     projectId: '',
+    companyIds: [],
   });
   const { user } = useAuth();
   const navigate = useNavigate();
@@ -33,6 +34,7 @@ const Surveys: React.FC = () => {
       description: '',
       questions: [],
       projectId: '',
+      companyIds: [],
     });
   }, []);
 


### PR DESCRIPTION
This commit addresses two issues in the survey creation form:

1. The 'Companies' multi-select dropdown is now always visible, regardless of the user's role. This allows all users with access to the form to associate multiple companies with a survey.

2. The `companyIds` field in the form state is now properly initialized and reset. This prevents potential bugs and ensures consistent form behavior.

These changes align the frontend with the backend's data model, which already supports the many-to-many relationship between surveys and companies, and the one-to-many relationship between projects and surveys.