### PR TITLE
feat: Activate Advanced Analytics & Reporting module for AGENT role

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -132,6 +132,11 @@ export const Sidebar: React.FC = () => {
           to: '/reports',
           icon: <BarChart3 />,
           label: 'Reports',
+        },
+        {
+          to: '/advanced-analytics',
+          icon: <PieChart />,
+          label: 'Advanced Analytics',
         }
       );
     } else if (user?.role === UserRole.CLIENT) {


### PR DESCRIPTION
This change activates the 'Advanced Analytics & Reporting' module for users with the 'AGENT' role by making the 'Advanced Analytics' link visible in the sidebar.

The 'Advanced Analytics' navigation item is now displayed for both 'ADMIN' and 'AGENT' roles, providing them with access to the advanced analytics features.