### PR TITLE
Feat: Restrict User and Company Management to Admins

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { useAuth } from '../../context/AuthContext';
+import { UserRole } from '../../types';
 
 const NavLink: React.FC<{ to: string; children: React.ReactNode }> = ({ to, children }) => (
   <Link to={to} className="text-gray-600 hover:text-gray-800">
@@ -27,8 +28,12 @@ const Header: React.FC = () => {
             <NavLink to="/reports">Reports</NavLink>
             <NavLink to="/multi-survey-dashboard">Multi-Survey Analysis</NavLink>
             <NavLink to="/market-research">Market Research</NavLink>
-            <NavLink to="/users">Users</NavLink>
-            <NavLink to="/companies">Companies</NavLink>
+            {user?.role === UserRole.ADMIN && (
+              <>
+                <NavLink to="/users">Users</NavLink>
+                <NavLink to="/companies">Companies</NavLink>
+              </>
+            )}
             <NavLink to="/settings">Settings</NavLink>
           </nav>
         </div>

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -65,21 +65,21 @@ export const Sidebar: React.FC = () => {
         icon: <Briefcase />,
         label: 'Projects',
       },
-      {
-        to: '/users',
-        icon: <Users />,
-        label: 'Users',
-      },
-      {
-        to: '/companies',
-        icon: <Building2 />,
-        label: 'Companies',
-      },
     ];
 
     // Role-specific nav items
     if (user?.role === UserRole.ADMIN) {
       items.push(
+        {
+          to: '/users',
+          icon: <Users />,
+          label: 'Users',
+        },
+        {
+          to: '/companies',
+          icon: <Building2 />,
+          label: 'Companies',
+        },
         {
           to: '/dashboard-module',
           icon: <Grid />,


### PR DESCRIPTION
This commit restricts the visibility of the "Users" and "Companies" management pages to users with the "admin" role.

The following changes were made:
- In `src/components/layout/Sidebar.tsx`, the "Users" and "Companies" navigation links have been moved to the admin-only section.
- In `src/components/layout/Header.tsx`, the "Users" and "Companies" navigation links are now conditionally rendered and will only be visible to admin users.

This aligns the UI with the intended functionality, where user and company management are administrative tasks.