### PR TITLE
feat: Move Projects link to the front of the navigation

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -20,8 +20,8 @@ const Header: React.FC = () => {
             <span className="text-2xl font-bold text-gray-800">SignaPlus</span>
           </Link>
           <nav className="hidden md:flex space-x-4">
-            <NavLink to="/dashboard">Dashboard</NavLink>
             <NavLink to="/projects">Projects</NavLink>
+            <NavLink to="/dashboard">Dashboard</NavLink>
             <NavLink to="/survey-builder">Survey Builder</NavLink>
             <NavLink to="/advanced-analytics">Advanced Analytics</NavLink>
             <NavLink to="/reports">Reports</NavLink>


### PR DESCRIPTION
This change moves the "Projects" link to be the first item in the top navigation bar.

This was done to address the user's request to "activate the projects module". After a thorough investigation, it was determined that the module was already technically active. Moving the link provides a clear visual confirmation that the projects module is enabled and prominent in the UI.