### PR TITLE
Fix: Prevent crash in users filter when name or email is missing

### DIFF
--- a/src/pages/Users.tsx
+++ b/src/pages/Users.tsx
@@ -500,8 +500,8 @@ useEffect(() => {
 
   // --- Render Logic ---
   const filteredUsers = users.filter(user =>
-    user.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
-    user.email.toLowerCase().includes(searchTerm.toLowerCase())
+    (user.name || '').toLowerCase().includes(searchTerm.toLowerCase()) ||
+    (user.email || '').toLowerCase().includes(searchTerm.toLowerCase())
   );
 
   if (isLoading) {


### PR DESCRIPTION
The user filtering logic in the `Users` page was throwing a `TypeError` when trying to call `toLowerCase()` on a user's `name` or `email` if either of those properties were `null` or `undefined`. This could happen if user records in the database were missing these fields.

This change makes the filtering logic more robust by providing an empty string as a fallback value before calling `toLowerCase()`. This ensures that the application does not crash when encountering incomplete user data.