### PR TITLE
Fix: Prevent temporal dead zone error in Companies page

### DIFF
--- a/src/pages/Companies.tsx
+++ b/src/pages/Companies.tsx
@@ -280,6 +280,12 @@ const Companies: React.FC = () => {
     resetForm();
   }, [resetForm]);
 
+  const handleCancelDelete = useCallback(() => {
+    setIsDeleteModalOpen(false);
+    setDeletingCompany(null);
+    setApiError(null);
+  }, []);
+
   const handleDeleteCompany = useCallback(async () => {
     if (!deletingCompany) return;
     setApiError(null);
@@ -299,12 +305,6 @@ const Companies: React.FC = () => {
   const openDeleteModal = useCallback((company: Company) => {
     setDeletingCompany(company);
     setIsDeleteModalOpen(true);
-  }, []);
-
-  const handleCancelDelete = useCallback(() => {
-    setIsDeleteModalOpen(false);
-    setDeletingCompany(null);
-    setApiError(null);
   }, []);
 
   const filteredCompanies = companies.filter(company =>


### PR DESCRIPTION
Reordered the `handleCancelDelete` function to be defined before the `handleDeleteCompany` function, which depends on it. This resolves a `ReferenceError: Cannot access '...' before initialization` that occurs due to the temporal dead zone (TDZ) for `const`-declared functions in React components when using `useCallback`.