### PR TITLE
feat: Add survey type to support different research methodologies

### DIFF
--- a/server/controllers/surveys.js
+++ b/server/controllers/surveys.js
@@ -7,7 +7,7 @@ import { Readable } from 'stream';
 export const createSurvey = async (req, res, next) => {
   console.log('createSurvey: Received request');
   try {
-    const { title, description, questions: inputQuestions, status, companyIds, agentId, customerId, projectId, headTeacherName, contactNumber } = req.body;
+    const { title, description, questions: inputQuestions, status, companyIds, agentId, customerId, projectId, headTeacherName, contactNumber, type } = req.body;
     console.log('createSurvey: Request body:', req.body);
     const { id: userId, role: userRole, companyId: userCompanyId } = req.user;
     console.log('createSurvey: User:', req.user);
@@ -45,6 +45,7 @@ export const createSurvey = async (req, res, next) => {
     const newSurveyData = {
       title,
       description: description || '',
+      type: type || 'descriptive',
       questions: validatedQuestions,
       status: 'active', // Always set status to active
       createdBy: new ObjectId(userId),

--- a/server/migrations/20250826043700_add_type_to_surveys.js
+++ b/server/migrations/20250826043700_add_type_to_surveys.js
@@ -1,0 +1,21 @@
+import { connectToServer, getDb } from '../utils/db.js';
+
+export const up = async (knex) => {
+  await connectToServer();
+  const db = getDb();
+  await db.collection('surveys').updateMany(
+    { type: { $exists: false } },
+    { $set: { type: 'descriptive' } }
+  );
+  console.log("Migration 'up' for adding type to surveys completed successfully.");
+};
+
+export const down = async (knex) => {
+  await connectToServer();
+  const db = getDb();
+  await db.collection('surveys').updateMany(
+    { type: 'descriptive' },
+    { $unset: { type: '' } }
+  );
+  console.log("Migration 'down' for adding type to surveys completed successfully.");
+};

--- a/src/components/surveys/SurveyForm.tsx
+++ b/src/components/surveys/SurveyForm.tsx
@@ -207,6 +207,21 @@ const SurveyForm = ({ formData, onFormDataChange, onSubmit, onCancel, buttonText
             className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 sm:text-sm"
           />
         </div>
+
+        <div className="mb-4">
+          <label htmlFor="type" className="block text-sm font-medium text-gray-700">Survey Type</label>
+          <select
+            id="type"
+            value={formData.type}
+            onChange={(e) => onFormDataChange({ ...formData, type: e.target.value })}
+            className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 sm:text-sm"
+          >
+            <option value="descriptive">Descriptive</option>
+            <option value="exploratory">Exploratory</option>
+            <option value="causal">Causal</option>
+          </select>
+        </div>
+
         <div className="mb-4">
             <label htmlFor="project" className="block text-sm font-medium text-gray-700">Project</label>
             <select

--- a/src/pages/Surveys.tsx
+++ b/src/pages/Surveys.tsx
@@ -13,12 +13,14 @@ const Surveys: React.FC = () => {
     agentId?: string;
     companyIds?: string[];
     projectId?: string;
+    type: string;
   }>({
     title: '',
     description: '',
     questions: [],
     projectId: '',
     companyIds: [],
+    type: 'descriptive',
   });
   const { user } = useAuth();
   const navigate = useNavigate();
@@ -35,6 +37,7 @@ const Surveys: React.FC = () => {
       questions: [],
       projectId: '',
       companyIds: [],
+      type: 'descriptive',
     });
   }, []);
 


### PR DESCRIPTION
This commit introduces a new 'type' field to the survey creation process, allowing users to classify surveys as 'descriptive', 'exploratory', or 'causal'. This is the first step in implementing the Market Research Module as outlined in the Business Requirements Document.

The changes include:
- Backend: The `createSurvey` controller now accepts and stores the survey type, with 'descriptive' as the default.
- Frontend: The `SurveyForm` component now includes a dropdown menu for selecting the survey type. The state management in the `Surveys` page has been updated to handle this new field.
- Database: A migration script has been added to update existing survey documents with a default 'type' field, ensuring data consistency.