### PR TITLE
feat: Implement multi-company survey assignment with role-based access

### DIFF
--- a/server/controllers/surveys.js
+++ b/server/controllers/surveys.js
@@ -311,13 +311,26 @@ export const updateSurvey = async (req, res, next) => {
       });
     }
 
-    if ((userRole === 'admin' || userRole === 'agent') && req.body.companyIds !== undefined) {
-      if (Array.isArray(req.body.companyIds)) {
-        updateFields.companyIds = req.body.companyIds
-          .filter(id => ObjectId.isValid(id))
-          .map(id => new ObjectId(id));
-      } else {
-        throw new ApiError(400, 'companyIds must be an array.');
+    if (req.body.companyIds !== undefined) {
+      if (userRole === 'admin') {
+        if (Array.isArray(req.body.companyIds)) {
+          updateFields.companyIds = req.body.companyIds
+            .filter(id => ObjectId.isValid(id))
+            .map(id => new ObjectId(id));
+        } else {
+          throw new ApiError(400, 'companyIds must be an array.');
+        }
+      } else if (userRole === 'agent') {
+        // Agents can only assign surveys to their own company.
+        // We will ignore any companyIds passed in the body and use the agent's companyId.
+        const { companyId: userCompanyId } = req.user;
+        if (userCompanyId && ObjectId.isValid(userCompanyId)) {
+            updateFields.companyIds = [new ObjectId(userCompanyId)];
+        } else {
+            // This case should ideally not happen if agents are always associated with a company.
+            // But as a safeguard, we prevent them from setting companyIds if they don't have one.
+            updateFields.companyIds = [];
+        }
       }
     }
 

--- a/src/components/surveys/SurveyForm.tsx
+++ b/src/components/surveys/SurveyForm.tsx
@@ -253,20 +253,22 @@ const SurveyForm = ({ formData, onFormDataChange, onSubmit, onCancel, buttonText
             </select>
           </div>
         )}
-        <div className="mb-4">
-          <label htmlFor="companies" className="block text-sm font-medium text-gray-700">Companies</label>
-          <select
-            id="companies"
-            multiple
-            value={formData.companyIds}
-            onChange={(e) => onFormDataChange({ ...formData, companyIds: Array.from(e.target.selectedOptions, option => option.value) })}
-            className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 sm:text-sm"
-          >
-            {companies.map(company => (
-              <option key={company._id} value={company._id}>{company.name}</option>
-            ))}
-          </select>
-        </div>
+        {user?.role === 'admin' && (
+          <div className="mb-4">
+            <label htmlFor="companies" className="block text-sm font-medium text-gray-700">Companies</label>
+            <select
+              id="companies"
+              multiple
+              value={formData.companyIds}
+              onChange={(e) => onFormDataChange({ ...formData, companyIds: Array.from(e.target.selectedOptions, option => option.value) })}
+              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 sm:text-sm"
+            >
+              {companies.map(company => (
+                <option key={company._id} value={company._id}>{company.name}</option>
+              ))}
+            </select>
+          </div>
+        )}
 
         <div className="mb-4">
           <h3 className="text-lg font-medium text-gray-900">Questions</h3>


### PR DESCRIPTION
This commit introduces role-based controls for assigning surveys to companies.

Backend:
- The `updateSurvey` controller is updated to restrict `agent` users to only assign surveys to their own company. `admin` users retain the ability to assign surveys to any company.
- The `createSurvey` controller already had the correct logic for handling company assignments for different user roles.

Frontend:
- The `SurveyForm.tsx` component is updated to only show the company selection field to `admin` users. For `agent` users, the survey is automatically associated with their company on the backend.