### PR TITLE
Fix: Correct proxy port in vite.config.ts

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
   server: {
     proxy: {
       '/api': {
-        target: 'http://localhost:3001', // Your backend server
+        target: 'http://localhost:5000', // Your backend server
         changeOrigin: true,
         secure: false,
       }


### PR DESCRIPTION
The frontend was configured to proxy API requests to port 3001, but the backend server runs on port 5000. This change updates the proxy target in vite.config.ts to the correct port, resolving the issue where the users and companies modules were not displaying content.