### PR TITLE
Fix: Change build output directory to 'build'

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,9 @@ import react from '@vitejs/plugin-react'
 
 export default defineConfig({
   plugins: [react()],
+  build: {
+    outDir: 'build',
+  },
   optimizeDeps: {
     exclude: ['lucide-react'],
   },


### PR DESCRIPTION
The deployment environment expects the build output to be in a 'build' directory, but Vite's default is 'dist'. This change configures Vite to output the build to the 'build' directory.

Fix: Correct proxy port in vite.config.ts

The frontend was configured to proxy API requests to port 3001, but the backend server runs on port 5000. This change updates the proxy target in vite.config.ts to the correct port.